### PR TITLE
Querystring

### DIFF
--- a/src/coffee/services/base.coffee
+++ b/src/coffee/services/base.coffee
@@ -40,6 +40,7 @@ class BaseService
     # Private: Container that holds request parameters such `id`, `query`, etc
     @_params =
       encoded: ['where', 'expand', 'sort']
+      plain: ['perPage', 'page']
       query:
         where: []
         operator: 'and'
@@ -239,11 +240,12 @@ class BaseService
       # when we rebuild the query string, we need to encode following parameters
       _.each @_params.encoded, (param) =>
         if parsed[param]
-          parsed[param] = _.map _.flatten([parsed[param]]), (p) -> encodeURIComponent(p)
-          if _.isArray @_params.query[param]
-            @_params.query[param].push = parsed[param]
-          else
+          if _.contains @_params.encoded, param
+            parsed[param] = _.map _.flatten([parsed[param]]), (p) -> encodeURIComponent(p)
             @_params.query[param] = parsed[param]
+      _.each @_params.plain, (param) =>
+        if parsed[param]
+          @_params.query[param] = parsed[param]
     @_params.queryString = _.stringifyQuery(parsed)
     debug 'setting queryString: %s', query
     this

--- a/src/coffee/services/base.coffee
+++ b/src/coffee/services/base.coffee
@@ -237,9 +237,13 @@ class BaseService
     parsed = _.parseQuery(query, false)
     unless withEncodedParams
       # when we rebuild the query string, we need to encode following parameters
-      _.each @_params.encoded, (param) ->
+      _.each @_params.encoded, (param) =>
         if parsed[param]
           parsed[param] = _.map _.flatten([parsed[param]]), (p) -> encodeURIComponent(p)
+          if _.isArray @_params.query[param]
+            @_params.query[param].push = parsed[param]
+          else
+            @_params.query[param] = parsed[param]
     @_params.queryString = _.stringifyQuery(parsed)
     debug 'setting queryString: %s', query
     this

--- a/src/coffee/services/product-projections.coffee
+++ b/src/coffee/services/product-projections.coffee
@@ -28,7 +28,8 @@ class ProductProjectionService extends BaseService
       facet: []
       searchKeywords: []
 
-    @_params.encoded = @_params.encoded.concat(['staged', 'filter', 'filter.query', 'filter.facets', 'facets', 'searchKeywords'])
+    @_params.encoded = @_params.encoded.concat(['filter', 'filter.query', 'filter.facets', 'facets', 'searchKeywords'])
+    @_params.plain = @_params.plain.concat(['staged'])
 
   # Public: Define whether to query for staged or current product projection.
   #

--- a/src/coffee/services/product-projections.coffee
+++ b/src/coffee/services/product-projections.coffee
@@ -27,8 +27,8 @@ class ProductProjectionService extends BaseService
       filterByFacets: []
       facet: []
       searchKeywords: []
-    _.extend @_params,
-      encoded: ['where', 'expand', 'sort', 'filter', 'filter.query', 'filter.facets', 'facets']
+
+    @_params.encoded = @_params.encoded.concat(['staged', 'filter', 'filter.query', 'filter.facets', 'facets', 'searchKeywords'])
 
   # Public: Define whether to query for staged or current product projection.
   #

--- a/src/spec/client/services/product-projections.spec.coffee
+++ b/src/spec/client/services/product-projections.spec.coffee
@@ -28,7 +28,7 @@ describe 'ProductProjectionService', ->
 
   it 'should reset default params', ->
     expect(@service._params).toEqual
-      encoded: ['where', 'expand', 'sort', 'filter', 'filter.query', 'filter.facets', 'facets']
+      encoded: ['where', 'expand', 'sort', 'staged', 'filter', 'filter.query', 'filter.facets', 'facets', 'searchKeywords']
       query:
         where: []
         operator: 'and'
@@ -113,7 +113,7 @@ describe 'ProductProjectionService', ->
       .facet('facet1:bar1')
       .facet('facet2:bar2')
     expect(@service._params).toEqual
-      encoded: ['where', 'expand', 'sort', 'filter', 'filter.query', 'filter.facets', 'facets']
+      encoded: ['where', 'expand', 'sort', 'staged', 'filter', 'filter.query', 'filter.facets', 'facets', 'searchKeywords']
       query:
         where: []
         operator: 'and'
@@ -132,7 +132,7 @@ describe 'ProductProjectionService', ->
         searchKeywords: []
     _service.search()
     expect(@service._params).toEqual
-      encoded: ['where', 'expand', 'sort', 'filter', 'filter.query', 'filter.facets', 'facets']
+      encoded: ['where', 'expand', 'sort', 'staged', 'filter', 'filter.query', 'filter.facets', 'facets', 'searchKeywords']
       query:
         where: []
         operator: 'and'

--- a/src/spec/client/services/product-projections.spec.coffee
+++ b/src/spec/client/services/product-projections.spec.coffee
@@ -28,7 +28,8 @@ describe 'ProductProjectionService', ->
 
   it 'should reset default params', ->
     expect(@service._params).toEqual
-      encoded: ['where', 'expand', 'sort', 'staged', 'filter', 'filter.query', 'filter.facets', 'facets', 'searchKeywords']
+      encoded: ['where', 'expand', 'sort', 'filter', 'filter.query', 'filter.facets', 'facets', 'searchKeywords']
+      plain: ['perPage', 'page', 'staged']
       query:
         where: []
         operator: 'and'
@@ -113,7 +114,8 @@ describe 'ProductProjectionService', ->
       .facet('facet1:bar1')
       .facet('facet2:bar2')
     expect(@service._params).toEqual
-      encoded: ['where', 'expand', 'sort', 'staged', 'filter', 'filter.query', 'filter.facets', 'facets', 'searchKeywords']
+      encoded: ['where', 'expand', 'sort', 'filter', 'filter.query', 'filter.facets', 'facets', 'searchKeywords']
+      plain: ['perPage', 'page', 'staged']
       query:
         where: []
         operator: 'and'
@@ -132,7 +134,8 @@ describe 'ProductProjectionService', ->
         searchKeywords: []
     _service.search()
     expect(@service._params).toEqual
-      encoded: ['where', 'expand', 'sort', 'staged', 'filter', 'filter.query', 'filter.facets', 'facets', 'searchKeywords']
+      encoded: ['where', 'expand', 'sort', 'filter', 'filter.query', 'filter.facets', 'facets', 'searchKeywords']
+      plain: ['perPage', 'page', 'staged']
       query:
         where: []
         operator: 'and'
@@ -158,6 +161,25 @@ describe 'ProductProjectionService', ->
 
     @service.byQueryString('filter=variants.price.centAmount%3A100&filter=variants.attributes.foo%3Abar&staged=true&limit=100&offset=2', true)
     expect(@service._params.queryString).toEqual 'filter=variants.price.centAmount%3A100&filter=variants.attributes.foo%3Abar&staged=true&limit=100&offset=2'
+
+  it 'should analyze and store params from queryString', ->
+    @service.byQueryString('where=productType(id="123")&perPage=100&staged=true')
+    expect(@service._params).toEqual
+      encoded: ['where', 'expand', 'sort', 'filter', 'filter.query', 'filter.facets', 'facets', 'searchKeywords']
+      plain: ['perPage', 'page', 'staged']
+      query:
+        where: ['productType(id%3D%22123%22)']
+        operator: 'and'
+        sort: []
+        expand: []
+        filter: []
+        filterByQuery: []
+        filterByFacets: []
+        facet: []
+        searchKeywords: []
+        perPage: '100'
+        staged: 'true'
+      queryString : 'where=productType(id%3D%22123%22)&perPage=100&staged=true'
 
   describe ':: search', ->
 


### PR DESCRIPTION
With this PR, we store each parameter from the querystring which is necessary if we use the process function for batch processing.

I used an explicit array for the plain attributes that don't need encoding.

@emmenko please review.

BTW: I don't know why only one search suggest job is failing in travis: https://travis-ci.org/sphereio/sphere-node-sdk/jobs/84246626