### PR TITLE
WIP  added searchKeywords update action

### DIFF
--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -299,32 +299,33 @@ class ProductUtils extends BaseUtils
         _.each keys, (k) =>
           # we pass also the value of the correspondent key of the original object
           # in case we need to patch for long text diffs
-          console.log("got k " + k)
+          # console.log("got k " + k)
           diffed_value = obj[k]
           if _.isArray diffed_value
             value = @getDeltaValue(diffed_value, old_obj[key][k])
-            console.log("got delta value " + JSON.stringify(value))
-            updated[k] = value
+            # console.log("got delta value array " + JSON.stringify(value))
+            updated[k] = value unless _.find value, (val) ->
+              _.has(val, 'text') and val['text'] is ""   #remove empty text
           else if _.isObject(diffed_value)
             # ok this is not an array - likely the searchKeywords - removing the garbage
-            console.log "got diffed value " + JSON.stringify(diffed_value)
+            # console.log "got diffed value " + JSON.stringify(diffed_value)
             if _.has(diffed_value, '_t') and diffed_value['_t'] is 'a'
               diffed_keywords = []
               diffed_keys = _.keys diffed_value
               _.each diffed_keys, (v) ->
-                console.log "got v " + JSON.stringify(v)
-                console.log "got old_obj[key][k] " + JSON.stringify(old_obj[key][k])
+                # console.log "got v " + JSON.stringify(v)
+                # console.log "got old_obj[key][k] " + JSON.stringify(old_obj[key][k])
                 if REGEX_NUMBER.test(v)
-                  console.log("got delta value " + JSON.stringify(diffed_value[v]))
+                  # console.log("got delta value " + JSON.stringify(diffed_value[v]))
                   diffed_keywords.push(diffed_value[v])
               diffed_keywords = _.flatten(diffed_keywords)
-              if not _.isEqual(diffed_keywords, old_obj[key][k])
-                console.log("got diffed_keywords " + JSON.stringify(diffed_keywords))
-                updated[k] = diffed_keywords
+              # console.log("got diffed_keywords " + JSON.stringify(diffed_keywords))
+              updated[k] = diffed_keywords unless _.isEqual(diffed_keywords, old_obj[key][k])
           else
             # no idea what this is but lets just use it for updating
             updated[k] = diffed_value
-      console.log("updated " + JSON.stringify(updated))
+      # console.log("updated " + JSON.stringify(updated))
+
       if old_obj[key]
         # extend values of original object with possible new values of the diffed object
         # e.g.:
@@ -342,6 +343,9 @@ class ProductUtils extends BaseUtils
         action[key] = old
       else
         action[key] = undefined
+      if _.isEmpty(updated) and key is "searchKeywords"
+        action = undefined
+        console.log "no update of search keywords"
     action
 
   _buildChangePriceAction: (centAmountDiff, variant, index) ->

--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -334,7 +334,7 @@ class ProductUtils extends BaseUtils
         #   => old = {en: undefined, de: 'bar'}
         old = _.deepClone old_obj[key]
         _.extend old, updated
-        console.log("new updated " + JSON.stringify(updated))
+        # ßconsole.log("new updated " + JSON.stringify(updated))
       else
         old = updated
       action =
@@ -345,7 +345,7 @@ class ProductUtils extends BaseUtils
         action[key] = undefined
       if _.isEmpty(updated) and key is "searchKeywords"
         action = undefined
-        console.log "no update of search keywords"
+        # console.log "no update of search keywords"
     action
 
   _buildChangePriceAction: (centAmountDiff, variant, index) ->

--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -460,7 +460,7 @@ class ProductUtils extends BaseUtils
               attrib.name is attribute.name
             text = _.extend {}, attrib?.value
             _.each diffed_value, (localValue, lang) =>
-              text[lang] = @getDeltaValue(localValue)
+              text[lang] = @getDeltaValue(localValue, attrib.value[lang])
             action.value = text
     action
 

--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -299,32 +299,24 @@ class ProductUtils extends BaseUtils
         _.each keys, (k) =>
           # we pass also the value of the correspondent key of the original object
           # in case we need to patch for long text diffs
-          # console.log("got k " + k)
           diffed_value = obj[k]
           if _.isArray diffed_value
             value = @getDeltaValue(diffed_value, old_obj[key][k])
-            # console.log("got delta value array " + JSON.stringify(value))
             updated[k] = value unless _.find value, (val) ->
               _.has(val, 'text') and val['text'] is ""   #remove empty text
           else if _.isObject(diffed_value)
             # ok this is not an array - likely the searchKeywords - removing the garbage
-            # console.log "got diffed value " + JSON.stringify(diffed_value)
             if _.has(diffed_value, '_t') and diffed_value['_t'] is 'a'
               diffed_keywords = []
               diffed_keys = _.keys diffed_value
               _.each diffed_keys, (v) ->
-                # console.log "got v " + JSON.stringify(v)
-                # console.log "got old_obj[key][k] " + JSON.stringify(old_obj[key][k])
                 if REGEX_NUMBER.test(v)
-                  # console.log("got delta value " + JSON.stringify(diffed_value[v]))
                   diffed_keywords.push(diffed_value[v])
               diffed_keywords = _.flatten(diffed_keywords)
-              # console.log("got diffed_keywords " + JSON.stringify(diffed_keywords))
               updated[k] = diffed_keywords unless _.isEqual(diffed_keywords, old_obj[key][k])
           else
             # no idea what this is but lets just use it for updating
             updated[k] = diffed_value
-      # console.log("updated " + JSON.stringify(updated))
 
       if old_obj[key]
         # extend values of original object with possible new values of the diffed object
@@ -334,7 +326,6 @@ class ProductUtils extends BaseUtils
         #   => old = {en: undefined, de: 'bar'}
         old = _.deepClone old_obj[key]
         _.extend old, updated
-        # ßconsole.log("new updated " + JSON.stringify(updated))
       else
         old = updated
       action =
@@ -345,7 +336,6 @@ class ProductUtils extends BaseUtils
         action[key] = undefined
       if _.isEmpty(updated) and key is "searchKeywords"
         action = undefined
-        # console.log "no update of search keywords"
     action
 
   _buildChangePriceAction: (centAmountDiff, variant, index) ->

--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -527,6 +527,10 @@ actionsBaseList = ->
     {
       action: 'setMetaKeywords'
       key: 'metaKeywords'
+    },
+    {
+      action: 'setSearchKeywords'
+      key: 'searchKeywords'
     }
   ]
 

--- a/src/spec/integration/products-sync.spec.coffee
+++ b/src/spec/integration/products-sync.spec.coffee
@@ -103,6 +103,10 @@ describe 'Integration Products Sync', ->
       description: {de: 'A foo product'}
       metaTitle: {de: 'The Foo'}
       metaDescription: {de: 'The Foo product'}
+      searchKeywords: {
+        en: [{text: 'new'}, {text: 'search'}, {text: 'keywords'}]
+        "fr-BE": [{text: 'bruxelles'}, {text:'liege'}, {text: 'brugge'}]
+      }
       masterVariant:
         id: 1
         sku: 'v0'
@@ -150,6 +154,8 @@ describe 'Integration Products Sync', ->
       expect(updated.masterVariant.prices[0].value.centAmount).toBe 1500
       expect(updated.masterVariant.prices[1].value.centAmount).toBe 1500
       expect(updated.masterVariant.prices[1].country).toBe 'IT'
+      expect(updated.searchKeywords.en[0].text).toBe 'new'
+      expect(updated.searchKeywords['fr-BE'][1].text).toBe 'liege'
       expect(updated.variants[0].sku).toBe 'v1'
       expect(updated.variants[0].prices[0].value.centAmount).toBe 2000
       expect(updated.variants[1].sku).toBe 'v2'

--- a/src/spec/integration/products.spec.coffee
+++ b/src/spec/integration/products.spec.coffee
@@ -171,7 +171,7 @@ describe 'Integration Products', ->
       ]
       .then -> done()
       .catch (error) -> done(_.prettify(error))
-    , 5000 # 5sec
+    , 20000 # 5sec
   , 30000 # 30sec
 
   it "should query using 'byQueryString'", (done) ->
@@ -199,7 +199,7 @@ describe 'Integration Products', ->
         expect(result.body.results[0].slug.en).toBe slugToLookFor
         done()
       .catch (error) -> done(_.prettify(error))
-    , 5000 # 5sec
+    , 20000 # 5sec
   , 20000 # 20sec
 
   it 'should uses search endpoint', (done) ->
@@ -220,7 +220,7 @@ describe 'Integration Products', ->
         expect(result.body.results[0].slug.en).toBe slugToLookFor
         done()
       .catch (error) -> done(_.prettify(error))
-    , 5000 # 5sec
+    , 20000 # 5sec
   , 20000 # 20sec
 
   it 'should search with full-text for special characters', (done) ->
@@ -239,5 +239,5 @@ describe 'Integration Products', ->
         expect(result.body.results[0].name.en).toBe specialChar
         done()
       .catch (error) -> done(_.prettify(error))
-    , 5000 # 5sec
+    , 20000 # 5sec
   , 20000 # 20sec

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -40,6 +40,9 @@ OLD_PRODUCT =
       ]
     }
   ]
+  searchKeywords: {
+    de: [{text: 'altes'}, {text: 'zeug'}, {text: 'weg'}]
+  }
 
 NEW_PRODUCT =
   id: '123'
@@ -79,6 +82,10 @@ NEW_PRODUCT =
       ]
     }
   ]
+  searchKeywords: {
+    en: [{text: 'new'}, {text: 'search'}, {text: 'keywords'}]
+    "fr-BE": [{text: 'bruxelles'}, {text:'liege'}, {text: 'brugge'}]
+  }
 
 describe 'ProductSync', ->
 
@@ -101,6 +108,7 @@ describe 'ProductSync', ->
           { action: 'changeName', name: {en: 'Foo', de: undefined, it: 'Boo'} }
           { action: 'changeSlug', slug: {en: 'foo', it: 'boo'} }
           { action: 'setDescription', description: undefined }
+          { action: 'setSearchKeywords', searchKeywords: en: [{text: 'new'}, {text: 'search'}, {text: 'keywords'}], "fr-BE": [{text: 'bruxelles'}, {text:'liege'}, {text: 'brugge'}] }
         ]
         version: OLD_PRODUCT.version
       expect(update).toEqual expected_update
@@ -115,6 +123,7 @@ describe 'ProductSync', ->
           { action: 'changeName', name: {en: 'Foo', de: undefined, it: 'Boo'} }
           { action: 'changeSlug', slug: {en: 'foo', it: 'boo'} }
           { action: 'setDescription', description: undefined }
+          { action: 'setSearchKeywords', searchKeywords: en: [{text: 'new'}, {text: 'search'}, {text: 'keywords'}], "fr-BE": [{text: 'bruxelles'}, {text:'liege'}, {text: 'brugge'}]}
           { action: 'changePrice', variantId: 1, price: {value: {currencyCode: 'EUR', centAmount: 3800}} }
           { action: 'removePrice', variantId: 1, price: {value: {currencyCode: 'EUR', centAmount: 1100}, country: 'DE'} }
           { action: 'removePrice', variantId: 1, price: {value: {currencyCode: 'EUR', centAmount: 1200}, customerGroup: {id: '984a64de-24a4-42c0-868b-da7abfe1c5f6', typeId: 'customer-group'}} }

--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -506,7 +506,7 @@ describe 'ProductUtils', ->
           attributes: [foo: 'bar']
       expect(=> @utils.diff(OLD, NEW)).toThrow new Error 'A variant must either have an ID or an SKU.'
 
-    it 'should diff basic attributes (name, slug, description)', ->
+    it 'should diff basic attributes (name, slug, description, searchKeywords)', ->
       OLD =
         id: '123'
         name:
@@ -548,7 +548,7 @@ describe 'ProductUtils', ->
         searchKeywords:
           en : 0 : [ { text : 'new' } ], 1 : [ { text : 'keywords' } ], _t : 'a', _0 : [ { text : 'old' }, 0, 0 ], _1 : [ { text : 'keywords' }, 0, 0 ]
           de : [ [ { text : 'alte' }, { text : 'schlagwoerter' } ], 0, 0 ]
-          it: [ {text: 'veccie'}, {text: 'parole'} ]
+          it: [[ {text: 'veccie'}, {text: 'parole'} ]]
       expect(delta).toEqual expected_delta
 
     it 'should diff missing attribute', ->

--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -516,6 +516,9 @@ describe 'ProductUtils', ->
           en: 'foo'
         description:
           en: 'Sample'
+        searchKeywords:
+          en: [ {text: 'old'}, {text: 'keywords'} ]
+          de: [ {text: 'alte'}, {text: 'schlagwoerter'} ]
         masterVariant:
           id: 1
       NEW =
@@ -527,6 +530,9 @@ describe 'ProductUtils', ->
         description:
           en: 'Sample'
           it: 'Esempio'
+        searchKeywords:
+          en: [ {text: 'new'}, {text: 'keywords'} ]
+          it: [ {text: 'veccie'}, {text: 'parole'} ]
         masterVariant:
           id: 1
 
@@ -539,6 +545,10 @@ describe 'ProductUtils', ->
           en: ['foo', 'boo']
         description:
           it: ['Esempio']
+        searchKeywords:
+          en : 0 : [ { text : 'new' } ], 1 : [ { text : 'keywords' } ], _t : 'a', _0 : [ { text : 'old' }, 0, 0 ], _1 : [ { text : 'keywords' }, 0, 0 ]
+          de : [ [ { text : 'alte' }, { text : 'schlagwoerter' } ], 0, 0 ]
+          it: [ {text: 'veccie'}, {text: 'parole'} ]
       expect(delta).toEqual expected_delta
 
     it 'should diff missing attribute', ->
@@ -653,6 +663,8 @@ describe 'ProductUtils', ->
         description:
           en: 'Sample'
           it: 'Esempio'
+        searchKeywords:
+          en: [ {text: 'new'}, {text: 'keyword'} ]
         masterVariant:
           id: 1
 
@@ -662,6 +674,7 @@ describe 'ProductUtils', ->
         { action: 'changeName', name: {en: undefined, de: 'Boo'} }
         { action: 'changeSlug', slug: {en: 'boo'} }
         { action: 'setDescription', description: {en: 'Sample', it: 'Esempio'} }
+        { action: 'setSearchKeywords', searchKeywords: {en: [ {text: 'new'}, {text: 'keyword'} ]} }
       ]
       expect(update).toEqual expected_update
 


### PR DESCRIPTION
Hi,
I added setSearchKeywords update action to the Product Sync.
Plz review @emmenko @hajoeichler 


thanks


for some reason this test fails though- although absolutely nothing has changed in that function - so it must have been an existing issue which looks more backend related:

```
  1) Integration Products should search for suggestions
   Message:
     Expected [  ] to equal [ { text : 'Schweizer Messer' } ].
```