### PR TITLE
feature(productProjection): add "old" process method

### DIFF
--- a/src/coffee/services/product-projections.coffee
+++ b/src/coffee/services/product-projections.coffee
@@ -1,6 +1,7 @@
 debug = require('debug')('sphere-client')
 _ = require 'underscore'
 BaseService = require './base'
+Promise = require 'bluebird'
 
 # Public: Define a `ProductProjectionService` to interact with the HTTP [`product-projections`](http://dev.sphere.io/http-api-projects-products.html) endpoint.
 # A [`ProductProjection`](http://dev.sphere.io/http-api-projects-products.html#product-projection) is a representation
@@ -353,7 +354,6 @@ class ProductProjectionService extends BaseService
   #   .catch (error) ->
   #     # eg: 'BAD'
   process: (fn, options = {}) ->
-    console.log @_currentEndpoint
     if @_currentEndpoint != '/product-projections/search'
       return super(fn, options)
     throw new Error 'Please provide a function to process the elements' unless _.isFunction fn
@@ -372,6 +372,7 @@ class ProductProjectionService extends BaseService
           perPage: perPage,
           offset: (page - 1) * perPage
           total: total
+
         if total? and (page - 1) * perPage >= total
           resolve acc
         else
@@ -398,7 +399,6 @@ class ProductProjectionService extends BaseService
               accumulated = acc.concat(result) if options.accumulate
               _processPage nextPage, perPage, newTotal, accumulated
           .catch (error) ->
-            console.log JSON.stringify error, null, 2
             reject error
           .done()
       _processPage(@_params.query.page or 1, @_params.query.perPage or 20)

--- a/src/spec/client/services/product-projections.spec.coffee
+++ b/src/spec/client/services/product-projections.spec.coffee
@@ -287,3 +287,39 @@ describe 'ProductProjectionService', ->
         expect(result[2].endpoint).toMatch /\?sort=name%20desc&staged=true&withTotal=false&where=foo%3Dbar%20or%20hello%3Dworld%20and%20id%20%3E%20%22id_20%22$/
         done()
       .catch (err) -> done(_.prettify err)
+
+    it 'should call the product-projection-search endpoint
+    when using asSearch', (done) ->
+      offset = -20
+      count = 20
+      spyOn(@restMock, 'GET').andCallFake (endpoint, callback) ->
+        offset += 20
+        callback(null, {statusCode: 200}, {
+          total: 50
+          count: if offset is 40 then 10 else count
+          offset: offset
+          results: _.map (if offset is 40 then [1..10] else [1..20]), (i) -> {id: "id_#{i}", endpoint}
+
+        })
+      fn = (payload) ->
+        Promise.resolve payload.body.results[0]
+      @service
+      .asSearch()
+      .process(fn)
+      .then (results) ->
+        allEndpointsAreSearch = _.reduce(results,
+          (allSearchEndpoints, request) ->
+            endpointIsSearch =
+              request.endpoint.match /^\/product-projections\/search/
+            return allSearchEndpoints && !!endpointIsSearch
+        )
+        actual = allEndpointsAreSearch
+        expected = true
+        expect(actual).toEqual(expected)
+        done()
+      .catch (err) -> done(_.prettify err)
+
+    it 'should throw error if function is missing', ->
+      spyOn(@restMock, 'GET')
+      expect(=> @service.asSearch().process()).toThrow new Error 'Please provide a function to process the elements'
+      expect(@restMock.GET).not.toHaveBeenCalled()


### PR DESCRIPTION
copied it from here: https://github.com/sphereio/sphere-node-sdk/blob/v1.3.7/src/coffee/services/base.coffee#L321
adaptions:
- use createdAt for sorting, since sorting by ID is not supported by the search endpoint
- fallback to the process function of base if the endpoint is not 'search'

@emmenko @hajoeichler 