### PR TITLE
fix(baseService): use limit of 20 if limit is 0

### DIFF
--- a/src/coffee/services/base.coffee
+++ b/src/coffee/services/base.coffee
@@ -336,6 +336,10 @@ class BaseService
       originalQuery = @_params.query
       originalPredicate = @_params.query.where
 
+      if originalQuery.perPage is 0
+        debug 'using batch size of 20 since 0 wont return any results'
+        originalQuery.perPage = 20
+
       _processPage = (lastId, acc = []) =>
         debug 'processing next page with id: %s', lastId
 

--- a/src/spec/client/services/base.spec.coffee
+++ b/src/spec/client/services/base.spec.coffee
@@ -389,6 +389,24 @@ describe 'Service', ->
           expect(=> @service.process()).toThrow new Error 'Please provide a function to process the elements'
           expect(@restMock.GET).not.toHaveBeenCalled()
 
+        it 'should set the limit to 20 if it is 0', ->
+          spyOn(@restMock, 'GET')
+
+          @service._params.query.perPage = 0
+
+          fn = (payload) ->
+            Promise.resolve payload.body.results[0]
+
+          @service.process(fn)
+          .then () ->
+
+            actual = @service._params.query.limit
+            expected = 20
+
+            expect(actual).toEqual(expected)
+            done()
+          .catch (error) -> done(_.prettify(error))
+
         it 'should not accumulate results if explicitly set', (done) ->
           offset = -20
           count = 1


### PR DESCRIPTION
Since the API was changed, so that limit=0 won't return any results
closes #106 
@emmenko @mmoelli 