### PR TITLE
Add windows support for npm scripts (cross-platform)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "node": ">= 0.10.0"
   },
   "scripts": {
-    "clean": "rm -rf dist && mkdir -p dist",
-    "coverage": "npm run lint && ./scripts/version && NODE_ENV=test babel-node $(npm bin)/isparta cover test",
-    "dist": "npm run clean && ./scripts/version && babel lib --out-dir dist",
+    "clean": "rimraf dist && mkdirp dist",
+    "coverage": "npm run lint && node ./scripts/version && cross-env NODE_ENV=test babel-node ./node_modules/isparta/bin/isparta cover test",
+    "dist": "npm run clean && node ./scripts/version && babel lib --out-dir dist",
     "lint": "eslint lib test",
-    "test": "./scripts/version && NODE_ENV=test NODE_PATH=./lib babel-node test/index.js | tap-spec",
-    "test:ci": "browserify -t babelify -t [ envify --NODE_ENV test ] test | tape-run -b firefox",
-    "test:browser": "browserify -t babelify -t [ envify --NODE_ENV test ] test | tape-run -b chrome",
-    "test:watch": "watch 'npm test' lib test -d"
+    "test": "node ./scripts/version && cross-env NODE_ENV=test NODE_PATH=./lib babel-node test/index.js | tap-spec",
+    "test:ci": "browserify -t babelify -t [ envify --NODE_ENV test ] test | tap-closer | smokestack -b firefox | tap-spec",
+    "test:browser": "browserify -t babelify -t [ envify --NODE_ENV test ] test | tap-closer | smokestack -b chrome | tap-spec",
+    "test:watch": "watch \"npm test\" lib test -d"
   },
   "dependencies": {
     "async": "~1.5.2",
@@ -45,14 +45,18 @@
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
     "coveralls": "^2.11.6",
+    "cross-env": "^1.0.7",
     "envify": "^3.4.0",
     "eslint": "^1.10.3",
     "eslint-config-commercetools": "^0.2.1",
     "isparta": "^4.0.0",
+    "mkdirp": "^0.5.1",
+    "rimraf": "^2.3.4",
     "sinon": "^1.17.3",
+    "smokestack": "^3.4.1",
+    "tap-closer": "^1.0.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.4.0",
-    "tape-run": "^2.1.3",
     "watch": "^0.17.1"
   },
   "keywords": [


### PR DESCRIPTION
With these changes I am able to run all npm scripts on windows.

- I replaced all commands which are not available under windows with cross-platform substitutions.
- Replaced `tape-run` with `smokestack` because tape-run was not able to detect browsers on windows. 