### PR TITLE
refactor(baseService): remove standard status code of 500

### DIFF
--- a/src/coffee/services/base.coffee
+++ b/src/coffee/services/base.coffee
@@ -561,7 +561,7 @@ class BaseService
       else
         errorMessage = error
       errorResp =
-        statusCode: response?.statusCode or 500
+        statusCode: response?.statusCode
         message: errorMessage
         originalRequest: originalRequest
       errorResp.body = body if body

--- a/src/spec/client/services/base.spec.coffee
+++ b/src/spec/client/services/base.spec.coffee
@@ -249,7 +249,6 @@ describe 'Service', ->
           .then -> done('Should not happen')
           .catch (error) ->
             expect(error.body).toEqual
-              statusCode: 500
               message: 'timeout'
               originalRequest:
                 options:
@@ -555,7 +554,6 @@ describe 'Service', ->
           .catch (error) ->
             expect(error.name).toBe 'HttpError'
             expect(error.body).toEqual
-              statusCode: 500
               message: 'foo'
               originalRequest:
                 options: {}
@@ -601,7 +599,6 @@ describe 'Service', ->
             .catch (error) ->
               expect(error.name).toBe 'HttpError'
               expect(error.body).toEqual
-                statusCode: 500
                 message: 'foo'
                 originalRequest:
                   options: {}
@@ -661,7 +658,6 @@ describe 'Service', ->
             .catch (error) ->
               expect(error.name).toBe 'HttpError'
               expect(error.body).toEqual
-                statusCode: 500
                 message: 'foo'
                 originalRequest:
                   options: {}
@@ -758,7 +754,6 @@ describe 'Service', ->
             .catch (error) ->
               expect(error.name).toBe 'HttpError'
               expect(error.body).toEqual
-                statusCode: 500
                 message: 'foo'
                 originalRequest:
                   options: {}


### PR DESCRIPTION
- [x] commit messages are commitizen-friendly
- [x] code is unit tested
- [x] code is integration tested
- [x] public code is documented
- [x] code is reviewed by at least one person
- [x] code satisfies linter rules

The status code 500 was also shown if there was no response from the server (timeout), which was
confusing since getting a status code looks like there was a response from the server.

closes #113 
/cc @emmenko 