### PR TITLE
fix(pagedRequest): set hasUniqueParams option to false

### DIFF
--- a/src/coffee/connect/rest.coffee
+++ b/src/coffee/connect/rest.coffee
@@ -181,7 +181,7 @@ class Rest
   PAGED: (resource, resolve) ->
     splitted = resource.split('?')
     endpoint = splitted[0]
-    query = _.parseQuery splitted[1]
+    query = _.parseQuery splitted[1], false
 
     throw new Error 'Query limit doesn\'t seem to be 0. This function queries all results, are you sure you want to use this?' if query.limit and query.limit isnt '0'
 

--- a/src/spec/connect/rest.spec.coffee
+++ b/src/spec/connect/rest.spec.coffee
@@ -256,6 +256,16 @@ describe 'Rest', ->
             withTotal: false
           done()
 
+      it 'should not overwrite duplicate url parameters', (done) ->
+        spyOn(@pagedRest, 'GET').andCallThrough()
+        @pagedRest.PAGED "/products?expand=foo&expand=bar", (e, r, b) =>
+          url = @pagedRest.GET.calls[0].args[0]
+          query = url.split('?')[1]
+          query = query.split('&')
+          expect(query[0]).toEqual('expand=foo')
+          expect(query[1]).toEqual('expand=bar')
+          done()
+
       it 'should correctly return error', (done) ->
         spyOn(@pagedRest, 'GET').andCallFake (endpoint, callback) ->
           callback('Oops', {statusCode: 500}, null)


### PR DESCRIPTION
- [x] commit messages are commitizen-friendly
- [x] code is unit tested
- [x] ~~code is integration tested~~
- [x] public code is documented
- [x] code is reviewed by at least one person
- [x] code satisfies linter rules

so that it is possible to for example expand multiple references

fixes #117