### PR TITLE
feat(categorySync): add support for syncing categories

### DIFF
--- a/lib/sync/categories.js
+++ b/lib/sync/categories.js
@@ -1,0 +1,47 @@
+import flatten from 'lodash.flatten'
+import createBuildActions from './utils/create-build-actions'
+import createMapActionGroup from './utils/create-map-action-group'
+import * as categoryActions from './category-actions'
+import * as diffpatcher from './utils/diffpatcher'
+
+export const actionGroups = [
+  'base', 'references', 'meta', 'custom'
+]
+
+function createCategoryMapActions (mapActionGroup) {
+  return function doMapActions (diff, newObj, oldObj/*, options*/) {
+    const allActions = []
+
+    allActions.push(mapActionGroup('base', () =>
+      categoryActions.actionsMapBase(diff, oldObj, newObj)))
+
+    allActions.push(mapActionGroup('references', () =>
+      categoryActions.actionsMapReferences(diff, oldObj, newObj)))
+
+    allActions.push(mapActionGroup('meta', () =>
+      categoryActions.actionsMapMeta(diff, oldObj, newObj)))
+
+    allActions.push(mapActionGroup('custom', () =>
+      categoryActions.actionsMapCustom(diff, oldObj, newObj)))
+
+    return flatten(allActions)
+  }
+}
+
+export default config => {
+  // config contains information about which action groups
+  // are white/black listed
+
+  // createMapActionGroup returns function 'mapActionGroup' that takes params:
+  // - action group name
+  // - callback function that should return a list of actions that correspond
+  //    to the for the action group
+
+  // this resulting function mapActionGroup will call the callback function
+  // for whitelisted action groups and return the return value of the callback
+  // It will return an empty array for blacklisted action groups
+  const mapActionGroup = createMapActionGroup(config)
+  const doMapActions = createCategoryMapActions(mapActionGroup)
+  const buildActions = createBuildActions(diffpatcher.diff, doMapActions)
+  return { buildActions }
+}

--- a/lib/sync/category-actions.js
+++ b/lib/sync/category-actions.js
@@ -1,0 +1,91 @@
+import forEach from 'lodash.foreach'
+import { buildBaseAttributesAction } from './utils/actions-utils'
+import * as diffpatcher from './utils/diffpatcher'
+
+function actionsBaseList () {
+  return [
+    { action: 'changeName', key: 'name' },
+    { action: 'changeSlug', key: 'slug' },
+    { action: 'setDescription', key: 'description' },
+    { action: 'changeOrderHint', key: 'orderHint' },
+    { action: 'setExternalId', key: 'externalId' }
+  ]
+}
+
+function actionsMetaList () {
+  return [
+    { action: 'setMetaTitle', key: 'metaTitle' },
+    { action: 'setMetaKeywords', key: 'metaKeywords' },
+    { action: 'setMetaDescription', key: 'metaDescription' }
+  ]
+}
+
+/**
+ * SYNC FUNCTIONS
+ */
+
+export function actionsMapBase (diff, oldObj, newObj) {
+  let actions = []
+
+  forEach(actionsBaseList(), item => {
+    const action = buildBaseAttributesAction(
+      item, diff, oldObj, newObj, diffpatcher.patch
+    )
+    if (action) actions.push(action)
+  })
+
+  return actions
+}
+
+export function actionsMapReferences (diff, oldObj, newObj) {
+  const actions = []
+  if (!diff.parent) return actions
+
+  actions.push({
+    action: 'changeParent',
+    parent: Array.isArray(diff.parent) ?
+      diffpatcher.getDeltaValue(diff.parent) : newObj.parent
+  })
+  return actions
+}
+
+export function actionsMapMeta (diff, oldObj, newObj) {
+  let actions = []
+
+  forEach(actionsMetaList(), item => {
+    const action = buildBaseAttributesAction(
+      item, diff, oldObj, newObj, diffpatcher.patch
+    )
+    if (action) actions.push(action)
+  })
+
+  return actions
+}
+export function actionsMapCustom (diff, oldObj, newObj) {
+  let actions = []
+  if (!diff.custom) return actions
+
+  if (diff.custom.type && diff.custom.type.id)
+    actions.push({
+      action: 'setCustomType',
+      type: {
+        typeId: 'type',
+        id: Array.isArray(diff.custom.type.id) ?
+          diffpatcher.getDeltaValue(diff.custom.type.id) : newObj.custom.type.id
+      },
+      fields: Array.isArray(diff.custom.fields) ?
+        diffpatcher.getDeltaValue(diff.custom.fields) : newObj.custom.fields
+    })
+  else if (diff.custom.fields) {
+    const customFieldsActions = Object.keys(diff.custom.fields).map(name => ({
+      action: 'setCustomField',
+      name,
+      value: Array.isArray(diff.custom.fields[name])
+        ? diffpatcher.getDeltaValue(diff.custom.fields[name])
+        : newObj.custom.fields[name]
+    }))
+    actions = actions.concat(customFieldsActions)
+  }
+
+  return actions
+}

--- a/lib/sync/product-actions.js
+++ b/lib/sync/product-actions.js
@@ -1,9 +1,9 @@
 /* eslint-disable max-len */
 import forEach from 'lodash.foreach'
 import unique from 'lodash.uniq'
-import clone from './utils/clone'
 import { find } from './utils/array'
 import * as diffpatcher from './utils/diffpatcher'
+import { buildBaseAttributesAction } from './utils/actions-utils'
 
 const REGEX_NUMBER = new RegExp(/^\d+$/)
 const REGEX_UNDERSCORE_NUMBER = new RegExp(/^\_\d+$/)
@@ -29,7 +29,9 @@ export function actionsMapBase (diff, oldObj, newObj) {
   let actions = []
 
   forEach(actionsBaseList(), item => {
-    const action = _buildBaseAttributesAction(item, diff, oldObj, newObj)
+    const action = buildBaseAttributesAction(
+      item, diff, oldObj, newObj, diffpatcher.patch
+    )
     if (action) actions.push(action)
   })
 
@@ -191,30 +193,6 @@ export function actionsMapPrices (diff, oldObj, newObj) {
 /**
  * HELPER FUNCTIONS
  */
-
-function _buildBaseAttributesAction (item, diff, oldObj, newObj) {
-  const key = item.key // e.g.: name, description, ...
-  const delta = diff[key]
-  const before = oldObj[key]
-  const now = newObj[key]
-
-  if (!delta) return undefined
-
-  if (!now && !before) return undefined
-
-  if (now && !before) // no value previously set
-    return { action: item.action, [key]: now }
-
-  if (!now && !newObj.hasOwnProperty(key)) // no new value
-    return undefined
-
-  if (!now && newObj.hasOwnProperty(key)) // value unset
-    return { action: item.action }
-
-  // We need to clone `before` as `patch` will mutate it
-  const patched = diffpatcher.patch(clone(before), delta)
-  return { action: item.action, [key]: patched }
-}
 
 
 function _buildSkuActions (variantDiff, oldVariant) {

--- a/lib/sync/utils/actions-utils.js
+++ b/lib/sync/utils/actions-utils.js
@@ -1,0 +1,27 @@
+import clone from './clone'
+
+export function buildBaseAttributesAction (
+  item, diff, oldObj, newObj, patchFn
+) {
+  const key = item.key // e.g.: name, description, ...
+  const delta = diff[key]
+  const before = oldObj[key]
+  const now = newObj[key]
+
+  if (!delta) return undefined
+
+  if (!now && !before) return undefined
+
+  if (now && !before) // no value previously set
+    return { action: item.action, [key]: now }
+
+  if (!now && !newObj.hasOwnProperty(key)) // no new value
+    return undefined
+
+  if (!now && newObj.hasOwnProperty(key)) // value unset
+    return { action: item.action }
+
+  // We need to clone `before` as `patch` will mutate it
+  const patched = patchFn(clone(before), delta)
+  return { action: item.action, [key]: patched }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -29,6 +29,9 @@ import './utils/task-queue.spec'
 import './utils/verbs.spec'
 import './utils/with-helpers.spec'
 
+
+import './sync/category-sync.spec'
+
 import './sync/product-sync-base.spec'
 import './sync/product-sync-images.spec'
 import './sync/product-sync-prices.spec'

--- a/test/sync/category-sync.spec.js
+++ b/test/sync/category-sync.spec.js
@@ -1,0 +1,262 @@
+import test from 'tape'
+import categorySyncFn, { actionGroups } from '../../lib/sync/categories'
+
+test('Sync::category', t => {
+
+  let categorySync
+  function setup () {
+    categorySync = categorySyncFn()
+  }
+
+  t.test('should export action group list', t => {
+    t.deepEqual(actionGroups, [
+      'base', 'references', 'meta', 'custom'
+    ])
+    t.end()
+  })
+
+  t.test('should build `changeName` action', t => {
+    setup()
+
+    const before = {
+      name: { en: 'pants', de: 'Hosen' }
+    }
+    const now = {
+      name: { en: 'shirts' }
+    }
+    const actual = categorySync.buildActions(now, before)
+    const expected = [
+      Object.assign({ action: 'changeName' }, now)
+    ]
+    t.deepEqual(actual, expected)
+    t.end()
+  })
+
+  t.test('should build `changeSlug` action', t => {
+    setup()
+
+    const before = {
+      slug: { en: 'skinny', de: 'eng' }
+    }
+    const now = {
+      slug: { en: 'baggy' }
+    }
+    const actual = categorySync.buildActions(now, before)
+    const expected = [
+      Object.assign({ action: 'changeSlug' }, now)
+    ]
+    t.deepEqual(actual, expected)
+    t.end()
+  })
+
+  t.test('should build `changeParent` action', t => {
+    setup()
+
+    const before = {
+      parent: {
+        typeId: 'category',
+        id: 'someCategoryId'
+      }
+    }
+    const now = {
+      parent: {
+        typeId: 'category',
+        id: 'someOtherCategoryId'
+      }
+    }
+    const actual = categorySync.buildActions(now, before)
+    const expected = [
+      Object.assign({ action: 'changeParent' }, now)
+    ]
+    t.deepEqual(actual, expected)
+    t.end()
+  })
+
+  t.test('should build `changeOrderHint` action', t => {
+    setup()
+
+    const before = {
+      orderHint: '1'
+    }
+    const now = {
+      orderHint: '2'
+    }
+    const actual = categorySync.buildActions(now, before)
+    const expected = [
+      Object.assign({ action: 'changeOrderHint' }, now)
+    ]
+    t.deepEqual(actual, expected)
+    t.end()
+  })
+  t.test('should build `setDescription` action', t => {
+    setup()
+
+    const before = {
+      description: {
+        en: 'a jeans that is very tight',
+        de: 'Eine Jeans-Hose, die sehr eng ist'
+      }
+    }
+    const now = {
+      description: {
+        en: 'a jeans that is very loose',
+        de: 'Eine Jeans-Hose, die sehr locker ist'
+      }
+    }
+    const actual = categorySync.buildActions(now, before)
+    const expected = [
+      Object.assign({ action: 'setDescription' }, now)
+    ]
+    t.deepEqual(actual, expected)
+    t.end()
+  })
+
+  t.test('should build `setExternalId` action', t => {
+    setup()
+
+    const before = {
+      externalId: 'externalId1'
+    }
+    const now = {
+      externalId: 'externalId2'
+    }
+    const actual = categorySync.buildActions(now, before)
+    const expected = [
+      Object.assign({ action: 'setExternalId' }, now)
+    ]
+    t.deepEqual(actual, expected)
+    t.end()
+  })
+
+  t.test('should build `setMetaTitle` action', t => {
+    setup()
+
+    const before = {
+      metaTitle: { en: 'pants', de: 'Hosen' }
+    }
+    const now = {
+      metaTitle: { en: 'shirts' }
+    }
+    const actual = categorySync.buildActions(now, before)
+    const expected = [
+      Object.assign({ action: 'setMetaTitle' }, now)
+    ]
+    t.deepEqual(actual, expected)
+    t.end()
+  })
+
+  t.test('should build `setMetaDescription` action', t => {
+    setup()
+
+    const before = {
+      metaDescription: { en: 'pants', de: 'Hosen' }
+    }
+    const now = {
+      metaDescription: { en: 'shirts' }
+    }
+    const actual = categorySync.buildActions(now, before)
+    const expected = [
+      Object.assign({ action: 'setMetaDescription' }, now)
+    ]
+    t.deepEqual(actual, expected)
+    t.end()
+  })
+
+  t.test('should build `setMetaKeywords` action', t => {
+    setup()
+
+    const before = {
+      metaKeywords: { en: 'pants', de: 'Hosen' }
+    }
+    const now = {
+      metaKeywords: { en: 'shirts' }
+    }
+    const actual = categorySync.buildActions(now, before)
+    const expected = [
+      Object.assign({ action: 'setMetaKeywords' }, now)
+    ]
+    t.deepEqual(actual, expected)
+    t.end()
+  })
+
+  t.test('should build `setCustomType` action', t => {
+    setup()
+
+    const before = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1'
+        },
+        fields: {
+          customField1: true
+        }
+      }
+    }
+    const now = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType2'
+        },
+        fields: {
+          customField1: true
+        }
+      }
+    }
+    const actual = categorySync.buildActions(now, before)
+    const expected = [
+      Object.assign({ action: 'setCustomType' }, now.custom)
+    ]
+    t.deepEqual(actual, expected)
+    t.end()
+  })
+
+  t.test('should build `setCustomField` action', t => {
+    setup()
+
+    const before = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1'
+        },
+        fields: {
+          customField1: true, // will change
+          customField2: true, // will stay unchanged
+          customField3: false // will be removed
+        }
+      }
+    }
+    const now = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1'
+        },
+        fields: {
+          customField1: false,
+          customField2: true,
+          customField4: true // was added
+        }
+      }
+    }
+    const actual = categorySync.buildActions(now, before)
+    const expected = [
+      Object.assign({ action: 'setCustomField' }, {
+        name: 'customField1',
+        value: false
+      }),
+      Object.assign({ action: 'setCustomField' }, {
+        name: 'customField3',
+        value: undefined
+      }),
+      Object.assign({ action: 'setCustomField' }, {
+        name: 'customField4',
+        value: true
+      })
+    ]
+    t.deepEqual(actual, expected)
+    t.end()
+  })
+})


### PR DESCRIPTION
- [x] commit messages are commitizen-friendly
- [x] code is unit tested
- [ ] code is integration tested
- [ ] public code is documented
- [x] code is reviewed by at least one person
- [x] code satisfies linter rules

#### Changes
- add category sync lib
- add action creators for all category actions support by the API
- refactored `_buildBaseAttributesAction` into `actions-utils.js`, since it may be used by multiple sync libs
- add unit tests for all possible category sync actions

cc/ @hajoeichler @emmenko @ct-dali