### PR TITLE
refactor(rest): prevent overwriting of sort when using all()

### DIFF
--- a/src/coffee/connect/rest.coffee
+++ b/src/coffee/connect/rest.coffee
@@ -169,8 +169,6 @@ class Rest
 
   # Public: Fetch all results of a Sphere resource query endpoint in batches of pages using a recursive function.
   #
-  # Note that traversing with pagination has been optimized. It now fetches pages sorted by `id` and iterates
-  # using a query with the `id` greater then the last one of the previous page.
   #
   # resource - {String} The API resource endpoint, with query string parameters.
   # resolve - {Function} A function fulfilled with `error, response, body` arguments. Body is an {Object} of `PagedQueryResponse`.
@@ -200,8 +198,6 @@ class Rest
       debug 'PAGED where predicate: %j', wherePredicate
 
       queryParams = _.stringifyQuery(_.extend({}, params,
-        sort: encodeURIComponent('id asc')
-        limit: limit
         withTotal: false
       , wherePredicate))
 

--- a/src/spec/connect/rest.spec.coffee
+++ b/src/spec/connect/rest.spec.coffee
@@ -3,6 +3,13 @@ _.mixin require('underscore-mixins')
 {Rest} = require '../../lib/main'
 Config = require('../../config').config
 
+idCounter = 0
+uniqueId = (prefix) ->
+  id = ++idCounter + ''
+  if prefix then prefix + id else id
+resetUniqueIdCounter = () ->
+  idCounter = 0
+
 describe 'Rest', ->
 
   it 'should initialize with default options', ->
@@ -210,10 +217,13 @@ describe 'Rest', ->
             total: 1004
             count: if offset is 1000 then 4 else count
             offset: offset
-            results: _.map (if offset is 1000 then [1..4] else [1..50]), (i) -> {id: _.uniqueId("_#{i}"), value: 'foo'}
-        spyOn(@pagedRest._oauth, 'getAccessToken').andCallFake (callback) -> callback(null, null, {access_token: 'foo'})
+            results: _.map (if offset is 1000 then [1..4] else [1..50]), (i) ->
+              {id: uniqueId("_#{i}") , value: 'foo'}
+        spyOn(@pagedRest._oauth, 'getAccessToken')
+          .andCallFake (callback) -> callback(null, null, {access_token: 'foo'})
 
       afterEach ->
+        resetUniqueIdCounter()
         @pagedRest = null
 
       it 'should send PAGED request', (done) ->
@@ -232,6 +242,7 @@ describe 'Rest', ->
           where: encodeURIComponent('sku in ("123", "456")')
           expand: 'productType'
           staged: true
+          sort: encodeURIComponent('createdAt asc')
         @pagedRest.PAGED "/products?#{queryParams}", (e, r, b) =>
           expect(e).toBe null
           expect(r.statusCode).toBe 200
@@ -244,15 +255,15 @@ describe 'Rest', ->
             where: encodeURIComponent('sku in ("123", "456")')
             expand: 'productType'
             staged: true
+            sort: encodeURIComponent('createdAt asc')
             limit: 50
-            sort: encodeURIComponent('id asc')
             withTotal: false
           expect(@pagedRest._doRequest.calls[1].args[0].uri).toEqual "https://api.sphere.io/#{Config.project_key}/products?" + _.stringifyQuery
-            where: encodeURIComponent('sku in ("123", "456") and id > "_501054"')
+            where: encodeURIComponent('sku in ("123", "456") and id > "_5050"')
             expand: 'productType'
             staged: true
+            sort: encodeURIComponent('createdAt asc')
             limit: 50
-            sort: encodeURIComponent('id asc')
             withTotal: false
           done()
 

--- a/src/spec/connect/rest.spec.coffee
+++ b/src/spec/connect/rest.spec.coffee
@@ -3,13 +3,6 @@ _.mixin require('underscore-mixins')
 {Rest} = require '../../lib/main'
 Config = require('../../config').config
 
-idCounter = 0
-uniqueId = (prefix) ->
-  id = ++idCounter + ''
-  if prefix then prefix + id else id
-resetUniqueIdCounter = () ->
-  idCounter = 0
-
 describe 'Rest', ->
 
   it 'should initialize with default options', ->
@@ -202,6 +195,13 @@ describe 'Rest', ->
           expect(rest._doRequest).toHaveBeenCalledWith(expected_options, jasmine.any(Function))
 
     describe ':: PAGED', ->
+
+      idCounter = 0
+      uniqueId = (prefix) ->
+        id = ++idCounter + ''
+        if prefix then prefix + id else id
+      resetUniqueIdCounter = () ->
+        idCounter = 0
 
       beforeEach ->
         opts =


### PR DESCRIPTION
- [x] commit messages are commitizen-friendly
- [x] code is unit tested
- [x] public code is documented
- [ ] code is reviewed by at least one person
- [x] code satisfies linter rules

Now you are able to provide your own sorting when doing `all()`. If you don't provide any sorting it
will still sort by id by default.

closes #122

cc @emmenko 