### PR TITLE
refactor(fetch): perPage(0) which corresponds to limit=0 no longer triggers a page request.

### DIFF
--- a/src/coffee/services/base.coffee
+++ b/src/coffee/services/base.coffee
@@ -47,6 +47,8 @@ class BaseService
         sort: []
         expand: []
 
+    @_fetchAll = false
+
   # Public: Build the endpoint path by appending the given id
   #
   # id - {String} The resource specific id
@@ -193,7 +195,7 @@ class BaseService
     debug 'setting perPage: %s', perPage
     this
 
-  # Public: A convenient method to set {::perPage} to `0`, which will fetch all pages
+  # Public: A convenient method to fetch all pages
   # recursively in chunks and return them all together once completed.
   #
   # Returns a chained instance of `this` class
@@ -202,7 +204,9 @@ class BaseService
   #
   #   service = client.products
   #   service.all().fetch()
-  all: -> @perPage(0)
+  all: ->
+    @_fetchAll = true
+    this
 
   # Public: Define an [ExpansionPath](http://dev.sphere.io/http-api.html#reference-expansion)
   # used for expanding [Reference](http://dev.sphere.io/http-api-types.html#reference)s of a resource.
@@ -284,7 +288,7 @@ class BaseService
       endpoint += "?#{queryString}" if queryString
       endpoint
 
-    if not @_params.queryString and @_params.query.perPage is 0
+    if not @_params.queryString and @_fetchAll is true
       # we should provide a default sorting when fetching all results
       @sort 'id' if _.isEmpty @_params.query.sort
       @_paged(_getEndpoint())

--- a/src/spec/client/services/base.spec.coffee
+++ b/src/spec/client/services/base.spec.coffee
@@ -169,10 +169,9 @@ describe 'Service', ->
       it 'should throw if perPage < 0', ->
         expect(=> @service.perPage(-1)).toThrow new Error 'PerPage (limit) must be a number >= 0'
 
-      it 'should alias \'all\' for \'perPage(0)\'', ->
-        spyOn(@service, 'perPage')
-        @service.perPage(0)
-        expect(@service.perPage).toHaveBeenCalledWith 0
+      it 'should set flag for \'all\'', ->
+        @service.all()
+        expect(@service._fetchAll).toBe(true)
 
       it 'should build query string', ->
         queryString = @service
@@ -207,7 +206,7 @@ describe 'Service', ->
       it 'should not use PAGED request when queryString is set', ->
         spyOn(@restMock, 'PAGED')
         spyOn(@restMock, 'GET')
-        @service.byQueryString('limit=10').perPage(0).fetch()
+        @service.byQueryString('limit=10').all().fetch()
         expect(@restMock.PAGED).not.toHaveBeenCalled()
         expect(@restMock.GET).toHaveBeenCalledWith "#{o.path}?limit=10", jasmine.any(Function)
 

--- a/src/spec/client/services/product-projections.spec.coffee
+++ b/src/spec/client/services/product-projections.spec.coffee
@@ -228,11 +228,11 @@ describe 'ProductProjectionService', ->
 
   describe ':: fetch', ->
 
-    it 'should fetch all with defaul sorting', (done) ->
+    it 'should fetch all with default sorting', (done) ->
       spyOn(@restMock, 'PAGED').andCallFake (endpoint, callback) -> callback(null, {statusCode: 200}, {total: 1, results: []})
       @service.where('foo=bar').staged(true).all().fetch()
       .then (result) =>
-        expect(@restMock.PAGED).toHaveBeenCalledWith "/product-projections?where=foo%3Dbar&limit=0&sort=id%20asc&staged=true", jasmine.any(Function)
+        expect(@restMock.PAGED).toHaveBeenCalledWith "/product-projections?where=foo%3Dbar&sort=id%20asc&staged=true", jasmine.any(Function)
         done()
       .catch (err) -> done(_.prettify err)
 


### PR DESCRIPTION
- [x] commit messages are commitizen-friendly
- [x] code is unit tested
- [ ] code is integration tested
- [x] public code is documented
- [x] code is reviewed by at least one person
- [x] code satisfies linter rules

Now the all() method no longer calls perPage(0) and thus set the limit=0. This is legacy since it
was used in the past to fetch all entries from a CTP API endpoint. Now doing limit=0 is used to get
the base stats without getting any results and all() is (still) beeing used to get all results from
an CTP API endpoint.

cc @emmenko 