### PR TITLE
Ensure that the updateActions work for field types that are objects

### DIFF
--- a/test/sync/category-sync.spec.js
+++ b/test/sync/category-sync.spec.js
@@ -308,4 +308,65 @@ test('Sync::category', t => {
     t.deepEqual(actual, expected)
     t.end()
   })
+
+  t.test('should build `setCustomField` action with Money values', t => {
+    setup()
+    const before = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1'
+        },
+        fields: {
+          moneyField1: { // will change
+            centAmount: 123000,
+            currencyCode: 'EUR'
+          },
+          moneyField2: { // wil be removed
+            centAmount: 213000,
+            currencyCode: 'EUR'
+          }
+        }
+      }
+    }
+
+    const now = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1'
+        },
+        fields: {
+          moneyField1: {
+            centAmount: 123000,
+            currencyCode: 'SEK'
+          },
+          moneyField3: {
+            centAmount: 213000,
+            currencyCode: 'USD'
+          }
+        }
+      }
+    }
+    const actual = categorySync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setCustomField',
+        name: 'moneyField1',
+        value: { centAmount: 123000, currencyCode: 'SEK' }
+      },
+      {
+        action: 'setCustomField',
+        name: 'moneyField2',
+        value: undefined
+      },
+      {
+        action: 'setCustomField',
+        name: 'moneyField3',
+        value: { centAmount: 213000, currencyCode: 'USD' }
+      }
+    ]
+    t.deepEqual(actual, expected)
+    t.end()
+  })
 })

--- a/test/sync/category-sync.spec.js
+++ b/test/sync/category-sync.spec.js
@@ -309,6 +309,74 @@ test('Sync::category', t => {
     t.end()
   })
 
+  t.test('should build `setCustomField` action with LocalizedEnum values',
+    t => {
+      setup()
+      const before = {
+        custom: {
+          type: {
+            typeId: 'type',
+            id: 'customType1'
+          },
+          fields: {
+            localizedEnumField1: {
+              "en": "lenum_en_1",
+              "de": "lenum_de_1" // will change
+            },
+            localizedEnumField2: { // will be removed
+              "en": "lenum_en_2",
+              "de": "lenum_de_2"
+            },
+          }
+        }
+      }
+
+      const now = {
+        custom: {
+          type: {
+            typeId: 'type',
+            id: 'customType1'
+          },
+          fields: {
+            localizedEnumField1: {
+              "en": "lenum_en_1",
+              "de": "lenum_de_2"
+            },
+            localizedEnumField3: { // was added
+              "en": "lenum_en_3",
+              "de": "lenum_de_3"
+            },
+          }
+        }
+      }
+      const actual = categorySync.buildActions(now, before)
+      const expected = [
+        {
+          action: 'setCustomField',
+          name: 'localizedEnumField1',
+          value: {
+            "en": "lenum_en_1",
+            "de": "lenum_de_2"
+          }
+        },
+        {
+          action: 'setCustomField',
+          name: 'localizedEnumField2',
+          value: undefined
+        },
+        {
+          action: 'setCustomField',
+          name: 'localizedEnumField3',
+          value: {
+            "en": "lenum_en_3",
+            "de": "lenum_de_3"
+          }
+        }
+      ]
+      t.deepEqual(actual, expected)
+      t.end()
+    })
+
   t.test('should build `setCustomField` action with Money values', t => {
     setup()
     const before = {

--- a/test/sync/category-sync.spec.js
+++ b/test/sync/category-sync.spec.js
@@ -224,7 +224,10 @@ test('Sync::category', t => {
         fields: {
           customField1: true, // will change
           customField2: true, // will stay unchanged
-          customField3: false // will be removed
+          customField3: false, // will be removed
+          customField4: {
+            key: 'enum_value_old'
+          }
         }
       }
     }
@@ -237,7 +240,10 @@ test('Sync::category', t => {
         fields: {
           customField1: false,
           customField2: true,
-          customField4: true // was added
+          customField4: {
+            key: 'enum_value_new'
+          },
+          customField5: true // was added
         }
       }
     }
@@ -253,6 +259,12 @@ test('Sync::category', t => {
       }),
       Object.assign({ action: 'setCustomField' }, {
         name: 'customField4',
+        value: {
+          key: 'enum_value_new'
+        }
+      }),
+      Object.assign({ action: 'setCustomField' }, {
+        name: 'customField5',
         value: true
       })
     ]

--- a/test/sync/category-sync.spec.js
+++ b/test/sync/category-sync.spec.js
@@ -224,10 +224,7 @@ test('Sync::category', t => {
         fields: {
           customField1: true, // will change
           customField2: true, // will stay unchanged
-          customField3: false, // will be removed
-          customField4: {
-            key: 'enum_value_old'
-          }
+          customField3: false // will be removed
         }
       }
     }
@@ -240,10 +237,7 @@ test('Sync::category', t => {
         fields: {
           customField1: false,
           customField2: true,
-          customField4: {
-            key: 'enum_value_new'
-          },
-          customField5: true // was added
+          customField4: true // was added
         }
       }
     }
@@ -259,14 +253,57 @@ test('Sync::category', t => {
       }),
       Object.assign({ action: 'setCustomField' }, {
         name: 'customField4',
-        value: {
-          key: 'enum_value_new'
-        }
-      }),
-      Object.assign({ action: 'setCustomField' }, {
-        name: 'customField5',
         value: true
       })
+    ]
+    t.deepEqual(actual, expected)
+    t.end()
+  })
+
+  t.test('should build `setCustomField` action with Enum values', t => {
+    setup()
+    const before = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1'
+        },
+        fields: {
+          enumField1: 'old_enum_value_1', // will change
+          enumField2: 'enum_value_2', // will be removed
+        }
+      }
+    }
+
+    const now = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1'
+        },
+        fields: {
+          enumField1: 'new_enum_value_1',
+          enumField3: 'enum_value_3'
+        }
+      }
+    }
+    const actual = categorySync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setCustomField',
+        name: 'enumField1',
+        value: 'new_enum_value_1'
+      },
+      {
+        action: 'setCustomField',
+        name: 'enumField2',
+        value: undefined
+      },
+      {
+        action: 'setCustomField',
+        name: 'enumField3',
+        value: 'enum_value_3'
+      }
     ]
     t.deepEqual(actual, expected)
     t.end()


### PR DESCRIPTION
This is related to some work I'm doing atm.
Wanted to double check that `buildActions` also works for fields that are objects (i.g Enum, LocalizedEnum, Money) 😉 

- [x] commit messages are commitizen-friendly
- [x] code is unit tested
- [ ] code is reviewed by at least one person
- [ ] code satisfies linter rules