### PR TITLE
Add support for generating update actions for product state transitions

### DIFF
--- a/src/coffee/errors.coffee
+++ b/src/coffee/errors.coffee
@@ -76,6 +76,19 @@ class NotFound extends SphereError
     @code = @statusCode
     Error.captureStackTrace(@, NotFound)
 
+# Public: A specific {SphereError} type for `MethodNotAllowed` errors (HTTP 405)
+class MethodNotAllowed extends SphereError
+
+  # Public: Create a new `MethodNotAllowed`
+  #
+  # message - {String} The error message
+  # body - {Object} A JSON object with optional information to pass to the error, like the error response body
+  constructor: (@message, @body = {}) ->
+    @name = "MethodNotAllowed"
+    @statusCode = 405
+    @code = @statusCode
+    Error.captureStackTrace(@, MethodNotAllowed)
+
 # Public: A specific {SphereError} type for `ConcurrentModification` errors (HTTP 409)
 class ConcurrentModification extends SphereError
 
@@ -123,6 +136,7 @@ module.exports =
     BadRequest: BadRequest
     Unauthorized: Unauthorized
     NotFound: NotFound
+    MethodNotAllowed: MethodNotAllowed
     ConcurrentModification: ConcurrentModification
     InternalServerError: InternalServerError
     ServiceUnavailable: ServiceUnavailable

--- a/src/coffee/services/base.coffee
+++ b/src/coffee/services/base.coffee
@@ -615,12 +615,6 @@ class BaseService
 
       # TODO: check other possible acceptable codes (304, ...)
       if 200 <= response.statusCode < 300
-        # FIXME: find a better solution
-        if @constructor.name is 'GraphQLService' and not body.data
-          graphqlError = new GraphQLError 'GraphQL error', _.extend responseJson, body,
-            statusCode: 400
-            originalRequest: originalRequest
-          return reject graphqlError
 
         return resolve _.extend responseJson,
           statusCode: response.statusCode
@@ -644,6 +638,12 @@ class BaseService
             statusCode: response.statusCode
             message: errMsg
             originalRequest: originalRequest
+      # FIXME: find a better solution
+      else if response.statusCode is 400 and @constructor.name is 'GraphQLService' and not body.data
+        graphqlError = new GraphQLError 'GraphQL error', _.extend responseJson, body,
+        statusCode: 400
+        originalRequest: originalRequest
+        return reject graphqlError
       else
         # a SphereError response e.g.: {statusCode: 400, message: 'Oops, something went wrong'}
         errorMessage = body.message or body.error_description or body.error or 'Undefined SPHERE.IO error message'

--- a/src/coffee/services/base.coffee
+++ b/src/coffee/services/base.coffee
@@ -631,8 +631,18 @@ class BaseService
         # we return a custom JSON error message
         reject new SphereHttpError.NotFound "Endpoint '#{endpoint}' not found.",
           _.extend responseJson,
-            statusCode: 404
+            statusCode: response.statusCode
             message: "Endpoint '#{endpoint}' not found."
+            originalRequest: originalRequest
+      else if response.statusCode is 405
+        endpoint = response.request.uri.path
+        # since the API doesn't return an error message for a unsupported method
+        # we return a custom JSON error message
+        errMsg = "The chosen HTTP method is not allowed for the endpoint '#{endpoint}'. This might be caused by a malformed request."
+        reject new SphereHttpError.MethodNotAllowed errMsg,
+          _.extend responseJson,
+            statusCode: response.statusCode
+            message: errMsg
             originalRequest: originalRequest
       else
         # a SphereError response e.g.: {statusCode: 400, message: 'Oops, something went wrong'}

--- a/src/coffee/services/base.coffee
+++ b/src/coffee/services/base.coffee
@@ -492,6 +492,11 @@ class BaseService
     # TODO: describe which endpoints support this?
     unless version
       throw new Error "Version is required for deleting a resource (endpoint: #{@_currentEndpoint})"
+    if @constructor.supportsByKey is true
+      unless (@_params.key or @_params.id)
+        throw new Error "Missing resource id. You can set it by chaining '.byId(ID)' or '.byKey(KEY)'" unless @_params.key or @_params.id
+    else
+      throw new Error "Missing resource id. You can set it by chaining '.byId(ID)'" unless @_params.id
 
     endpoint = "#{@_currentEndpoint}?version=#{version}"
     @_delete(endpoint)

--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -155,6 +155,21 @@ class ProductUtils extends BaseUtils
           action: 'setTaxCategory'
           taxCategory: new_obj.taxCategory
         actions.push action
+    if diff.state
+      if _.isArray diff.state.id
+        action =
+          action: 'transitionState'
+          state:
+            typeId: 'state'
+            id: @getDeltaValue diff.state.id
+        actions.push action
+      else
+        action =
+          action: 'transitionState'
+          state:
+            typeId: 'state'
+            id: new_obj.state.id
+        actions.push action
     actions
 
   # Private: map product categories

--- a/src/spec/client/services/base.spec.coffee
+++ b/src/spec/client/services/base.spec.coffee
@@ -761,6 +761,25 @@ describe 'Service', ->
             expect(=> @service.delete()).toThrow new Error "Version is required for deleting a resource (endpoint: #{@service._currentEndpoint})"
             expect(@restMock.DELETE).not.toHaveBeenCalled()
 
+          if not _.contains(o.blacklist, 'byKey')
+
+            it 'should send request for current endpoint with Key', ->
+              spyOn(@restMock, 'DELETE')
+              @service.byKey(KEY).delete(1)
+              expect(@restMock.DELETE).toHaveBeenCalledWith "#{o.path}/key=#{KEY}?version=1", jasmine.any(Function)
+
+            it 'should throw error if id and key is missing', ->
+              spyOn(@restMock, 'DELETE')
+              expect(=> @service.delete(1)).toThrow new Error "Missing resource id. You can set it by chaining '.byId(ID)' or '.byKey(KEY)'"
+              expect(@restMock.DELETE).not.toHaveBeenCalled()
+
+          else
+
+            it 'should throw error if id is missing', ->
+              spyOn(@restMock, 'DELETE')
+              expect(=> @service.delete(1)).toThrow new Error "Missing resource id. You can set it by chaining '.byId(ID)'"
+              expect(@restMock.DELETE).not.toHaveBeenCalled()
+
           it 'should return promise on delete', ->
             promise = @service.byId('123-abc').delete(1)
             expect(promise.isPending()).toBe true

--- a/src/spec/errors.spec.coffee
+++ b/src/spec/errors.spec.coffee
@@ -6,6 +6,7 @@ ERRORS = [
   {name: 'BadRequest', statusCode: 400}
   {name: 'Unauthorized', statusCode: 401}
   {name: 'NotFound', statusCode: 404}
+  {name: 'MethodNotAllowed', statusCode: 405}
   {name: 'ConcurrentModification', statusCode: 409}
   {name: 'InternalServerError', statusCode: 500}
   {name: 'ServiceUnavailable', statusCode: 503}

--- a/src/spec/integration/products-sync.spec.coffee
+++ b/src/spec/integration/products-sync.spec.coffee
@@ -373,5 +373,4 @@ describe 'Integration Products Sync', ->
       )
       .catch (error) ->
         done(_.prettify(error))
-        console.log(JSON.stringify(error, null, 2))
     , 10000 # 10sec

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -11,6 +11,9 @@ OLD_PRODUCT =
     en: 'sapphire1366126441922'
   description:
     en: 'Sample description'
+  state:
+    typeId: 'state'
+    id: 'old-state-id'
   masterVariant:
     id: 1
     prices: [
@@ -52,6 +55,9 @@ NEW_PRODUCT =
   slug:
     en: 'foo'
     it: 'boo'
+  state:
+    typeId: 'state'
+    id: 'new-state-id'
   masterVariant:
     id: 1
     prices: [
@@ -128,6 +134,7 @@ describe 'ProductSync', ->
           { action: 'setCategoryOrderHint', categoryId : 'myFancyCategoryId', orderHint : 0.9 }
           { action: 'setDescription', description: undefined }
           { action: 'setSearchKeywords', searchKeywords: en: [{text: 'new'}, {text: 'search'}, {text: 'keywords'}], "fr-BE": [{text: 'bruxelles'}, {text:'liege'}, {text: 'brugge'}]}
+          { action: 'transitionState', state: { typeId: 'state', id: 'new-state-id' } }
           { action: 'changePrice', variantId: 1, price: {value: {currencyCode: 'EUR', centAmount: 3800}} }
           { action: 'removePrice', variantId: 1, price: {value: {currencyCode: 'EUR', centAmount: 1100}, country: 'DE'} }
           { action: 'removePrice', variantId: 1, price: {value: {currencyCode: 'EUR', centAmount: 1200}, customerGroup: {id: '984a64de-24a4-42c0-868b-da7abfe1c5f6', typeId: 'customer-group'}} }

--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -1309,51 +1309,96 @@ describe 'ProductUtils', ->
       expect(update[0]).toEqual {action: 'changePrice', variantId: 2, price: {value: {currencyCode: 'EUR', centAmount: 5}, customerGroup: {id: '987', typeId: 'customer-group'}}}
       expect(update[1]).toEqual {action: 'addPrice', variantId: 1, price: {value: {currencyCode: 'EUR', centAmount: 20}, country: 'DE'}}
 
-  describe ':: actionsMapReferences (tax-category)', ->
+  describe ':: actionsMapReferences', ->
 
-    beforeEach ->
-      @utils = new ProductUtils
-      @OLD_REFERENCE =
-        id: '123'
-        taxCategory:
-          typeId: 'tax-category'
-          id: 'tax-de'
-        masterVariant:
-          id: 1
+    describe ':: tax-category', ->
 
-      @NEW_REFERENCE =
-        id: '123'
-        taxCategory:
-          typeId: 'tax-category'
-          id: 'tax-us'
-        masterVariant:
-          id: 1
+      beforeEach ->
+        @utils = new ProductUtils
+        @OLD_REFERENCE =
+          id: '123'
+          taxCategory:
+            typeId: 'tax-category'
+            id: 'tax-de'
+          masterVariant:
+            id: 1
 
-    it 'should build action to change tax-category', ->
-      delta = @utils.diff @OLD_REFERENCE, @NEW_REFERENCE
-      update = @utils.actionsMapReferences delta, @OLD_REFERENCE, @NEW_REFERENCE
-      expected_update = [
-        { action: 'setTaxCategory', taxCategory: { typeId: 'tax-category', id: 'tax-us' } }
-      ]
-      expect(update).toEqual expected_update
+        @NEW_REFERENCE =
+          id: '123'
+          taxCategory:
+            typeId: 'tax-category'
+            id: 'tax-us'
+          masterVariant:
+            id: 1
 
-    it 'should build action to delete tax-category', ->
-      delete @NEW_REFERENCE.taxCategory
-      delta = @utils.diff @OLD_REFERENCE, @NEW_REFERENCE
-      update = @utils.actionsMapReferences delta, @OLD_REFERENCE, @NEW_REFERENCE
-      expected_update = [
-        { action: 'setTaxCategory' }
-      ]
-      expect(update).toEqual expected_update
+      it 'should build action to change tax-category', ->
+        delta = @utils.diff @OLD_REFERENCE, @NEW_REFERENCE
+        update = @utils.actionsMapReferences delta, @OLD_REFERENCE, @NEW_REFERENCE
+        expected_update = [
+          { action: 'setTaxCategory', taxCategory: { typeId: 'tax-category', id: 'tax-us' } }
+        ]
+        expect(update).toEqual expected_update
 
-    it 'should build action to add tax-category', ->
-      delete @OLD_REFERENCE.taxCategory
-      delta = @utils.diff @OLD_REFERENCE, @NEW_REFERENCE
-      update = @utils.actionsMapReferences delta, @OLD_REFERENCE, @NEW_REFERENCE
-      expected_update = [
-        { action: 'setTaxCategory', taxCategory: { typeId: 'tax-category', id: 'tax-us' } }
-      ]
-      expect(update).toEqual expected_update
+      it 'should build action to delete tax-category', ->
+        delete @NEW_REFERENCE.taxCategory
+        delta = @utils.diff @OLD_REFERENCE, @NEW_REFERENCE
+        update = @utils.actionsMapReferences delta, @OLD_REFERENCE, @NEW_REFERENCE
+        expected_update = [
+          { action: 'setTaxCategory' }
+        ]
+        expect(update).toEqual expected_update
+
+      it 'should build action to add tax-category', ->
+        delete @OLD_REFERENCE.taxCategory
+        delta = @utils.diff @OLD_REFERENCE, @NEW_REFERENCE
+        update = @utils.actionsMapReferences delta, @OLD_REFERENCE, @NEW_REFERENCE
+        expected_update = [
+          { action: 'setTaxCategory', taxCategory: { typeId: 'tax-category', id: 'tax-us' } }
+        ]
+        expect(update).toEqual expected_update
+
+    describe ':: state', ->
+
+      beforeEach ->
+        @utils = new ProductUtils
+        @OLD_REFERENCE =
+          id: '123'
+          state:
+            typeId: 'state'
+            id: 'old-state-id'
+          masterVariant:
+            id: 1
+
+        @NEW_REFERENCE =
+          id: '123'
+          state:
+            typeId: 'state'
+            id: 'new-state-id'
+          masterVariant:
+            id: 1
+
+      it 'should build a transitionState action for the initial state', ->
+        oldRef = _.extend({}, @OLD_REFERENCE, { state: null })
+        delta = @utils.diff oldRef, @NEW_REFERENCE
+        actual = @utils.actionsMapReferences(
+          delta, oldRef, @NEW_REFERENCE
+        )
+        expected = [{
+          action: 'transitionState',
+          state: { typeId: 'state', id: 'new-state-id' }
+        }]
+        expect(actual).toEqual(expected)
+
+      it 'should build a transitionState action for a state change', ->
+        delta = @utils.diff @OLD_REFERENCE, @NEW_REFERENCE
+        actual = @utils.actionsMapReferences(
+          delta, @OLD_REFERENCE, @NEW_REFERENCE
+        )
+        expected = [{
+          action: 'transitionState',
+          state: { typeId: 'state', id: 'new-state-id' }
+        }]
+        expect(actual).toEqual(expected)
 
   describe ':: actionsMapCategories (category)', ->
 


### PR DESCRIPTION
#### Changes
- check if `byId` or `byKey` were used before calling `delete`. This previously would lead to a program error in the SDK, which is also fixed now with this PR 4d2f4b3
- handle 405 errors and show descriptive error message, since the CTP API does not provide one
- fix handling of graphql 400 errors. Previously these would not occur with status code 400. Since the now do this update was needed. abae23c
- add support for generating update actions for product transitions
- add unit and integration tests for product state transition actions


#### DOD
- [x] commit messages are commitizen-friendly
- [x] code is unit tested
- [x] code is integration tested
- [x] public code is documented
- [x] code is reviewed by at least one person
- [x] code satisfies linter rules

cc/ @emmenko @hajoeichler @butenkor 