### PR TITLE
Don't generate update actions when no state is provided

### DIFF
--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -164,12 +164,19 @@ class ProductUtils extends BaseUtils
             id: @getDeltaValue diff.state.id
         actions.push action
       else
-        action =
-          action: 'transitionState'
-          state:
-            typeId: 'state'
-            id: new_obj.state.id
-        actions.push action
+        # check if there is a new state to transition to
+        # otherwise no transition action is generated
+        # since transitioning to an empty state is not allowed
+        # this adds incosistency to some degree because for all other actions
+        # passing null as the new value results in a remove action
+        # which does not exist for states
+        if !!new_obj.state
+          action =
+            action: 'transitionState'
+            state:
+              typeId: 'state'
+              id: new_obj.state.id
+          actions.push action
     actions
 
   # Private: map product categories

--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -1390,6 +1390,26 @@ describe 'ProductUtils', ->
         expect(actual).toEqual(expected)
 
       it 'should build a transitionState action for a state change', ->
+        # test with { state: null }
+        newRef = _.extend({}, @NEW_REFERENCE, { state: null })
+        delta = @utils.diff @OLD_REFERENCE, newRef
+        actual = @utils.actionsMapReferences(
+          delta, @OLD_REFERENCE, newRef
+        )
+        expected = []
+        expect(actual).toEqual(expected)
+
+        # test without state
+        delete newRef.state
+        delta = @utils.diff @OLD_REFERENCE, newRef
+        actual = @utils.actionsMapReferences(
+          delta, @OLD_REFERENCE, newRef
+        )
+        expected = []
+        expect(actual).toEqual(expected)
+
+      it 'should not build a transitionState action if no state is provided
+      even if the product already has a state', ->
         delta = @utils.diff @OLD_REFERENCE, @NEW_REFERENCE
         actual = @utils.actionsMapReferences(
           delta, @OLD_REFERENCE, @NEW_REFERENCE

--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -1389,7 +1389,8 @@ describe 'ProductUtils', ->
         }]
         expect(actual).toEqual(expected)
 
-      it 'should build a transitionState action for a state change', ->
+      it 'should not build a transitionState action if no state is provided
+      even if the product already has a state', ->
         # test with { state: null }
         newRef = _.extend({}, @NEW_REFERENCE, { state: null })
         delta = @utils.diff @OLD_REFERENCE, newRef
@@ -1408,8 +1409,7 @@ describe 'ProductUtils', ->
         expected = []
         expect(actual).toEqual(expected)
 
-      it 'should not build a transitionState action if no state is provided
-      even if the product already has a state', ->
+      it 'should build a transitionState action for a state change', ->
         delta = @utils.diff @OLD_REFERENCE, @NEW_REFERENCE
         actual = @utils.actionsMapReferences(
           delta, @OLD_REFERENCE, @NEW_REFERENCE


### PR DESCRIPTION
- [x] commit messages are commitizen-friendly
- [x] code is unit tested
- [x] code is reviewed by at least one person
- [x] code satisfies linter rules

Since the API throws an error when you try to set the state to null, there is no sence in letting
the user run into this. It is a common use case that the state is not known and not important to
some importing service.

#137

cc @butenkor 