### PR TITLE
fix(product-sync): allow unsetting of sku if one was set

### DIFF
--- a/lib/sync/product-actions.js
+++ b/lib/sync/product-actions.js
@@ -195,7 +195,7 @@ export function actionsMapPrices (diff, oldObj, newObj) {
 function _buildSkuActions (variantDiff, oldVariant) {
   if (variantDiff.hasOwnProperty('sku')) {
     const newValue = diffpatcher.getDeltaValue(variantDiff.sku)
-    if (!newValue) return null
+    if (!newValue && !oldVariant.sku) return null
 
     return {
       action: 'setSku',

--- a/test/sync/product-sync-variants.spec.js
+++ b/test/sync/product-sync-variants.spec.js
@@ -261,6 +261,30 @@ test('Sync::product::variants', t => {
     t.end()
   })
 
+  t.test('should handle unsetting the sku of a variant', t => {
+    setup()
+
+    const before = {
+      id: '123',
+      masterVariant: {
+        id: 1, sku: 'v1', attributes: [{ name: 'foo', value: 'bar' }],
+      },
+    }
+
+    const now = {
+      id: '123',
+      masterVariant: {
+        sku: '', attributes: [{ name: 'foo', value: 'bar' }],
+      },
+    }
+
+    const actions = productsSync.buildActions(now, before)
+    t.deepEqual(actions, [
+      { action: 'setSku', sku: '', variantId: 1 },
+    ])
+    t.end()
+  })
+
   t.test('should build attribute actions for all types', t => {
     setup()
 
@@ -334,6 +358,31 @@ test('Sync::product::variants', t => {
       id: '123',
       masterVariant: {
         id: 1,
+      },
+      variants: [{ id: 2 }],
+    }
+
+    const now = {
+      id: '123',
+      masterVariant: {
+        id: 1, sku: '',
+      },
+      variants: [{ id: 2, sku: null }],
+    }
+
+    const actions = productsSync.buildActions(now, before)
+    t.deepEqual(actions, [], 'should not generate any action')
+    t.end()
+  })
+
+  t.test('should ignore set sku if the sku was and still is empty', t => {
+    setup()
+
+    // Case when sku is not set, and the new value is empty or null
+    const before = {
+      id: '123',
+      masterVariant: {
+        id: 1, sku: '',
       },
       variants: [{ id: 2 }],
     }


### PR DESCRIPTION
#### Summary

This is a bug that was noticed in the MC. At the moment when you unset the SKU of an existing variant (that has an SKU set), there is no update action generated.
This is now changed, so that the only case where no update action is generated is when the old and the new draft have no SKU set (or an empty SKU)

#### DoD

- [x] commit messages are commitizen-friendly
- [x] code is unit tested
- [x] code is reviewed by at least one person
- [x] code satisfies linter rules

#### Reviewers

- [x] @emmenko has approved the PR
- [x] @adnasa has approved this PR

