### PR TITLE
[2.0] feat(auth): automatically renew an access_token before it expires

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ function defaultOptions (options = {}) {
     Promise: options.Promise || Promise,
     auth: {
       accessToken: auth.accessToken,
+      accessTokenExpirationTime: auth.accessTokenExpiresIn,
       credentials: auth.credentials || {},
       shouldRetrieveToken: auth.shouldRetrieveToken || (cb => { cb(true) }),
       host: auth.host || 'auth.sphere.io',

--- a/src/utils/task-queue.js
+++ b/src/utils/task-queue.js
@@ -35,10 +35,8 @@ export default options => {
    */
   function hasValidAccessToken () {
     if (!auth.accessToken) return false
-
     const { accessTokenExpirationTime: expirationTime } = auth
-    if (expirationTime && Date.now() > expirationTime) return false
-    return true
+    return !(expirationTime && Date.now() > expirationTime)
   }
 
   /**
@@ -69,7 +67,12 @@ export default options => {
         else {
           queue.pause()
 
-          authUtils.getAccessToken(options)
+          authUtils.getAccessToken(Object.assign({}, options, {
+            auth: Object.assign({}, options.auth, {
+              accessToken: undefined,
+              accessTokenExpirationTime: undefined,
+            }),
+          }))
           .then(({ body }) => {
             // TODO: use a setter
             options.auth.accessToken = body.access_token // eslint-disable-line

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -78,6 +78,7 @@ test('SphereClient', t => {
       Promise: { foo: 'bar' },
       auth: {
         accessToken: undefined,
+        accessTokenExpirationTime: undefined,
         credentials,
         shouldRetrieveToken,
         host: 'auth.sphere.io',

--- a/test/utils/task-queue.spec.js
+++ b/test/utils/task-queue.spec.js
@@ -49,4 +49,78 @@ test('Utils::taskQueue', t => {
     })
     .catch(t.end)
   })
+
+  t.test('should renew access token before it expires', t => {
+    const fetchResponseMock = (status, body) => Promise.resolve({
+      headers: {},
+      status,
+      ok: status === 200,
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(JSON.stringify(body)),
+    })
+
+    let apiCalls = 0
+    const httpMock = (url, fetchOptions) => {
+      if (url === 'https://test_client:test_secret@auth.sphere.io/oauth/token') // eslint-disable-line
+        return fetchResponseMock(200, {
+          access_token: `token${apiCalls}`,
+          expires_in: 2 * 60 * 60 - 1, // 1h59m59s
+          scope: 'manage_project:test',
+          token_type: 'Bearer',
+        })
+
+      const { Authorization } = fetchOptions.headers
+      const result = Authorization === `Bearer token${apiCalls}` ?
+        fetchResponseMock(200, { foo: 'bar' }) :
+        fetchResponseMock(401, { error: 'Invalid token' })
+
+      // A token is only valid for one api call.
+      // All returned tokens expire in 1h59m59s.
+      // The client implementation should request a new token if
+      // the token expires in less than 2 hours, ie
+      // it should use a new token for every api call.
+      apiCalls++
+
+      return result
+    }
+
+    options = {
+      Promise: Promise, // eslint-disable-line object-shorthand
+      auth: {
+        credentials: {
+          clientId: 'test_client',
+          clientSecret: 'test_secret',
+          projectKey: 'test_project',
+        },
+        shouldRetrieveToken (cb) { cb(true) },
+        host: 'auth.sphere.io',
+      },
+      request: {
+        maxParallel: 20,
+        headers: {},
+        host: 'api.sphere.io',
+        protocol: 'https',
+      },
+      httpMock,
+    }
+
+    const taskQueue = taskQueueFn(options)
+
+    const task = {
+      method: 'GET',
+      url: 'https://api.sphere.io/foo',
+    }
+
+    taskQueue.addTask(task)
+      .then(res => {
+        t.deepEqual(res.body, { foo: 'bar' })
+
+        return taskQueue.addTask(task)
+          .then(res => {
+            t.deepEqual(res.body, { foo: 'bar' })
+            t.end()
+          })
+      })
+      .catch(t.end)
+  })
 })

--- a/test/utils/task-queue.spec.js
+++ b/test/utils/task-queue.spec.js
@@ -61,15 +61,24 @@ test('Utils::taskQueue', t => {
 
     let apiCalls = 0
     const httpMock = (url, fetchOptions) => {
-      if (url === 'https://test_client:test_secret@auth.sphere.io/oauth/token') // eslint-disable-line
+      const { Authorization } = fetchOptions.headers
+
+      if (url === 'https://test_client:test_secret@auth.sphere.io/oauth/token') { // eslint-disable-line
+        // Ensure credentials are sent with url
+        // and not with Authorization header
+        if (Authorization) return fetchResponseMock(401, {
+          error: 'The client should not send the Authorization header.',
+        })
+
         return fetchResponseMock(200, {
           access_token: `token${apiCalls}`,
           expires_in: 2 * 60 * 60 - 1, // 1h59m59s
           scope: 'manage_project:test',
           token_type: 'Bearer',
         })
+      }
 
-      const { Authorization } = fetchOptions.headers
+
       const result = Authorization === `Bearer token${apiCalls}` ?
         fetchResponseMock(200, { foo: 'bar' }) :
         fetchResponseMock(401, { error: 'Invalid token' })


### PR DESCRIPTION
This adds automatic renewal of the access_token to the `rewrite-2.0` branch.

When you merge `2.0-beta-middleware-api` you'll need to tweak the inner implementation, but you should be able to use more or less the same test.
- [x] commit messages are commitizen-friendly
- [x] code is unit tested
- [ ] code is integration tested
- [ ] public code is documented
- [ ] code is reviewed by at least one person
- [x] code satisfies linter rules
