### PR TITLE
fix(product-sync): fix setting multiple category order hints at once

### DIFF
--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -96,10 +96,19 @@ class ProductUtils extends BaseUtils
         # if the the category order hint was changed from {} to not existant
         if action.categoryOrderHints is undefined
           return
-        action.categoryId = Object.keys(action.categoryOrderHints)[0]
-        action.orderHint = action.categoryOrderHints[action.categoryId]
-        action = _.pick action, ['action', 'categoryId', 'orderHint']
-      actions.push action if action
+        orderHintActions = Object.keys(action.categoryOrderHints)
+          .map((categoryId) ->
+            orderHint = action.categoryOrderHints[categoryId]
+            unless _.isNumber(orderHint)
+              orderHint = undefined
+
+            action: 'setCategoryOrderHint'
+            categoryId: categoryId
+            orderHint: orderHint
+          )
+        actions = actions.concat(orderHintActions)
+      else
+        actions.push action if action
     actions
 
   # Private: map product variants

--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -762,6 +762,7 @@ describe 'ProductUtils', ->
           id: 1
         categoryOrderHints:
           abc: 0.3
+          anotherCategoryId: 0.1
 
       delta = @utils.diff OLD, NEW
       update = @utils.actionsMapBase(delta, OLD)
@@ -770,6 +771,42 @@ describe 'ProductUtils', ->
           action: 'setCategoryOrderHint'
           categoryId: 'abc'
           orderHint: 0.3
+        }, {
+          action: 'setCategoryOrderHint'
+          categoryId: 'anotherCategoryId'
+          orderHint: 0.1
+        },
+      ]
+      expect(update).toEqual expected_update
+
+    it 'should generate a setCategoryOrderHint action to unset order hints', ->
+      OLD =
+        id: '123'
+        masterVariant:
+          id: 1
+        categoryOrderHints:
+          abc: 0.9
+          anotherCategoryId: 0.5
+      NEW =
+        id: '123'
+        masterVariant:
+          id: 1
+        categoryOrderHints:
+          abc: null
+          anotherCategoryId: 0
+
+      delta = @utils.diff OLD, NEW
+      update = @utils.actionsMapBase(delta, OLD)
+      expected_update = [
+        {
+          action: 'setCategoryOrderHint'
+          categoryId: 'abc',
+          orderHint: undefined,
+        },
+        {
+          action: 'setCategoryOrderHint'
+          categoryId: 'anotherCategoryId',
+          orderHint: 0,
         }
       ]
       expect(update).toEqual expected_update


### PR DESCRIPTION
- [x] commit messages are commitizen-friendly
- [x] code is unit tested
- ~~code is integration tested~~
- ~~public code is documented~~
- [ ] code is reviewed by at least one person
- [x] code satisfies linter rules

