### PR TITLE
fix(product-sync): stringify order hint values

### DIFF
--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -99,9 +99,13 @@ class ProductUtils extends BaseUtils
         orderHintActions = Object.keys(action.categoryOrderHints)
           .map((categoryId) ->
             orderHint = action.categoryOrderHints[categoryId]
-            unless _.isNumber(orderHint)
+            if orderHint is null or orderHint is undefined
               orderHint = undefined
-
+            else
+              # stringify the order hint so that javascript numbers also get
+              # accepted as values
+              # for empty string we assume that the orderHint should be unset
+              orderHint = "#{orderHint}" || undefined
             action: 'setCategoryOrderHint'
             categoryId: categoryId
             orderHint: orderHint

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -115,7 +115,7 @@ describe 'ProductSync', ->
         actions: [
           { action: 'changeName', name: {en: 'Foo', de: undefined, it: 'Boo'} }
           { action: 'changeSlug', slug: {en: 'foo', it: 'boo'} }
-          { action: 'setCategoryOrderHint', categoryId : 'myFancyCategoryId', orderHint : 0.9 }
+          { action: 'setCategoryOrderHint', categoryId : 'myFancyCategoryId', orderHint : '0.9' }
           { action: 'setDescription', description: undefined }
           { action: 'setSearchKeywords', searchKeywords: en: [{text: 'new'}, {text: 'search'}, {text: 'keywords'}], "fr-BE": [{text: 'bruxelles'}, {text:'liege'}, {text: 'brugge'}] }
         ]
@@ -131,7 +131,7 @@ describe 'ProductSync', ->
         actions: [
           { action: 'changeName', name: {en: 'Foo', de: undefined, it: 'Boo'} }
           { action: 'changeSlug', slug: {en: 'foo', it: 'boo'} }
-          { action: 'setCategoryOrderHint', categoryId : 'myFancyCategoryId', orderHint : 0.9 }
+          { action: 'setCategoryOrderHint', categoryId : 'myFancyCategoryId', orderHint : '0.9' }
           { action: 'setDescription', description: undefined }
           { action: 'setSearchKeywords', searchKeywords: en: [{text: 'new'}, {text: 'search'}, {text: 'keywords'}], "fr-BE": [{text: 'bruxelles'}, {text:'liege'}, {text: 'brugge'}]}
           { action: 'transitionState', state: { typeId: 'state', id: 'new-state-id' } }

--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -755,14 +755,14 @@ describe 'ProductUtils', ->
         masterVariant:
           id: 1
         categoryOrderHints:
-          abc: 0.9
+          abc: '0.9'
       NEW =
         id: '123'
         masterVariant:
           id: 1
         categoryOrderHints:
-          abc: 0.3
-          anotherCategoryId: 0.1
+          abc: '0.3'
+          anotherCategoryId: '0.1'
 
       delta = @utils.diff OLD, NEW
       update = @utils.actionsMapBase(delta, OLD)
@@ -770,11 +770,11 @@ describe 'ProductUtils', ->
         {
           action: 'setCategoryOrderHint'
           categoryId: 'abc'
-          orderHint: 0.3
+          orderHint: '0.3'
         }, {
           action: 'setCategoryOrderHint'
           categoryId: 'anotherCategoryId'
-          orderHint: 0.1
+          orderHint: '0.1'
         },
       ]
       expect(update).toEqual expected_update
@@ -785,15 +785,17 @@ describe 'ProductUtils', ->
         masterVariant:
           id: 1
         categoryOrderHints:
-          abc: 0.9
-          anotherCategoryId: 0.5
+          abc: '0.9'
+          anotherCategoryId: '0.5'
+          categoryId: '0.5'
       NEW =
         id: '123'
         masterVariant:
           id: 1
         categoryOrderHints:
           abc: null
-          anotherCategoryId: 0
+          anotherCategoryId: '0'
+          categoryId: ''
 
       delta = @utils.diff OLD, NEW
       update = @utils.actionsMapBase(delta, OLD)
@@ -806,7 +808,12 @@ describe 'ProductUtils', ->
         {
           action: 'setCategoryOrderHint'
           categoryId: 'anotherCategoryId',
-          orderHint: 0,
+          orderHint: '0',
+        }
+        {
+          action: 'setCategoryOrderHint'
+          categoryId: 'categoryId',
+          orderHint: undefined,
         }
       ]
       expect(update).toEqual expected_update


### PR DESCRIPTION
- [x] commit messages are commitizen-friendly
- [x] code is unit tested
- ~~code is integration tested~~
- ~~public code is documented~~
- [x] code is reviewed by at least one person
- [x] code satisfies linter rules

