### PR TITLE
fix(product-actions): use correct uniq function to ensure unique sfa attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jsondiffpatch": "emmenko/jsondiffpatch#patch-webpack",
     "lodash.flatten": "^4.2.0",
     "lodash.foreach": "^4.2.0",
-    "lodash.uniq": "^4.2.1",
+    "lodash.uniqwith": "^4.5.0",
     "loose-envify": "^1.1.0"
   },
   "devDependencies": {

--- a/src/sync/product-actions.js
+++ b/src/sync/product-actions.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import forEach from 'lodash.foreach'
-import unique from 'lodash.uniq'
+import uniqWith from 'lodash.uniqwith'
 import * as diffpatcher from './utils/diffpatcher'
 import {
   buildBaseAttributesActions,
@@ -152,9 +152,13 @@ export function actionsMapAttributes (
       }
     })
 
-  // Ensure we have each action only once per product.
-  // Use string representation of object to allow `===` on array objects
-  return unique(actions, action => JSON.stringify(action))
+  // Ensure that an action is unique.
+  // This is especially necessary for SFA attributes.
+  return uniqWith(actions, (a, b) =>
+    a.action === b.action &&
+    a.name === b.name &&
+    a.variantId === b.variantId
+  )
 }
 
 export function actionsMapImages (diff, oldObj, newObj) {

--- a/test/sync/product-sync-variants.spec.js
+++ b/test/sync/product-sync-variants.spec.js
@@ -113,9 +113,20 @@ test('Sync::product::variants', (t) => {
         id: 1,
         attributes: [
           { name: 'color', value: 'red' },
+          { name: 'size', value: 'M' },
+          { name: 'weigth', value: '1' },
         ],
       },
-      variants: [],
+      variants: [
+        {
+          id: 2,
+          attributes: [
+            { name: 'color', value: 'red' },
+            { name: 'size', value: 'M' },
+            { name: 'weigth', value: '2' },
+          ],
+        },
+      ],
     }
 
     const now = {
@@ -123,20 +134,43 @@ test('Sync::product::variants', (t) => {
       masterVariant: {
         id: 1,
         attributes: [
+          // new
           { name: 'vendor', value: 'ferrari' },
+          // changed
           { name: 'color', value: 'yellow' },
+          // removed
+          { name: 'size', value: undefined },
+          // normal attribute
+          { name: 'weigth', value: '3' },
         ],
       },
-      variants: [],
+      variants: [
+        {
+          id: 2,
+          attributes: [
+            // new
+            { name: 'vendor', value: 'ferrari' },
+            // changed
+            { name: 'color', value: 'yellow' },
+            // removed
+            { name: 'size', value: undefined },
+            // normal attribute
+            { name: 'weigth', value: '4' },
+          ],
+        },
+      ],
     }
 
     const actions = productsSync.buildActions(now, before, {
-      sameForAllAttributeNames: ['vendor'],
+      sameForAllAttributeNames: ['vendor', 'color', 'size'],
     })
 
     t.deepEqual(actions, [
       { action: 'setAttributeInAllVariants', name: 'vendor', value: 'ferrari' },
-      { action: 'setAttribute', variantId: 1, name: 'color', value: 'yellow' },
+      { action: 'setAttributeInAllVariants', name: 'color', value: 'yellow' },
+      { action: 'setAttributeInAllVariants', name: 'size', value: undefined },
+      { action: 'setAttribute', variantId: 1, name: 'weigth', value: '3' },
+      { action: 'setAttribute', variantId: 2, name: 'weigth', value: '4' },
     ])
     t.end()
   })


### PR DESCRIPTION
#### Summary
Fix a problem for product update actions where duplicate SFA attributes were generated.

#### Description
If multiple variants have the same SFA attribute, and this somehow changed (added, removed, changed), multiple equal actions were generated.

The problem was that the wrong lodash function was used, which allows to filter out from an array non-unique items.

#### TODO
- Tests
    - [x] Unit