### PR TITLE
don't generate actions when updating non existant attributes with empty value

### DIFF
--- a/src/sync/product-actions.js
+++ b/src/sync/product-actions.js
@@ -256,8 +256,12 @@ function _buildVariantAttributesActions (
   forEach(attributes, (value, key) => {
     if (REGEX_NUMBER.test(key)) {
       if (Array.isArray(value)) {
+        // this attribute did not exist before on the product
         const { id } = oldVariant
         const deltaValue = diffpatcher.getDeltaValue(value)
+        // if there is no new value, and the attribute did not even exist before
+        // we don't need to generate any action at all
+        if (!deltaValue.value) return
         const setAction =
           _buildNewSetAttributeAction(id, deltaValue, sameForAllAttributeNames)
 

--- a/test/sync/product-sync-variants.spec.js
+++ b/test/sync/product-sync-variants.spec.js
@@ -142,6 +142,8 @@ test('Sync::product::variants', (t) => {
           { name: 'size', value: undefined },
           // normal attribute
           { name: 'weigth', value: '3' },
+          // non existent value removed
+          { name: 'length', value: undefined },
         ],
       },
       variants: [
@@ -156,13 +158,15 @@ test('Sync::product::variants', (t) => {
             { name: 'size', value: undefined },
             // normal attribute
             { name: 'weigth', value: '4' },
+            // non existent value removed
+            { name: 'length', value: undefined },
           ],
         },
       ],
     }
 
     const actions = productsSync.buildActions(now, before, {
-      sameForAllAttributeNames: ['vendor', 'color', 'size'],
+      sameForAllAttributeNames: ['vendor', 'color', 'size', 'length'],
     })
 
     t.deepEqual(actions, [


### PR DESCRIPTION
- [x] commit messages are commitizen-friendly
- [x] code is unit tested
- [ ] code is integration tested
- [ ] public code is documented
- [ ] code is reviewed by at least one person
- [x] code satisfies linter rules

cc/ @emmenko 