### PR TITLE
fix(product-actions): correctly pass original obj for patching long text diff

### DIFF
--- a/src/sync/utils/diffpatcher.js
+++ b/src/sync/utils/diffpatcher.js
@@ -33,7 +33,7 @@ export function patch (obj, delta) {
   return diffpatcher.patch(obj, delta)
 }
 
-export function getDeltaValue (arr, obj) {
+export function getDeltaValue (arr, originalObject) {
   if (!Array.isArray(arr))
     throw new Error('Expected array to extract delta value')
 
@@ -44,11 +44,11 @@ export function getDeltaValue (arr, obj) {
   if (arr.length === 3 && arr[2] === 0) return undefined // delete
 
   if (arr.length === 3 && arr[2] === 2) { // text diff
-    if (!obj)
+    if (!originalObject)
       throw new Error('Cannot apply patch to long text diff. ' +
         'Missing original object.')
     // try to apply patch to given object based on delta value
-    return jsondiffpatch.patch(obj, arr)
+    return jsondiffpatch.patch(originalObject, arr)
   }
 
   if (arr.length === 3 && arr[2] === 3) // array move

--- a/test/sync/product-sync-base.spec.js
+++ b/test/sync/product-sync-base.spec.js
@@ -198,4 +198,62 @@ test('Sync::product::base', (t) => {
     ])
     t.end()
   })
+
+  t.test('should build base actions for long diff text', (t) => {
+    setup()
+
+    const longText = `
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nunc ultricies fringilla tortor eu egestas.
+    Praesent rhoncus molestie libero, eu tempor sapien placerat id.
+    Donec commodo nunc sed nulla scelerisque, eu pulvinar augue egestas.
+    Donec at leo dolor. Cras at molestie arcu.
+    Sed non fringilla quam, sit amet ultricies massa.
+    Donec luctus tempus erat, ut suscipit elit varius nec.
+    Mauris dolor enim, aliquet sed nulla et, dignissim lobortis augue.
+    Proin pharetra magna eu neque semper tristique sed.
+    `
+
+    /* eslint-disable max-len */
+    const before = {
+      name: {
+        en: longText,
+      },
+      slug: {
+        en: longText,
+      },
+      description: {
+        en: longText,
+      },
+    }
+    const now = {
+      name: {
+        en: `Hello, ${longText}`,
+      },
+      slug: {
+        en: `Hello, ${longText}`,
+      },
+      description: {
+        en: `Hello, ${longText}`,
+      },
+    }
+    /* eslint-enable max-len */
+    const actions = productsSync.buildActions(now, before)
+
+    t.deepEqual(actions, [
+      {
+        action: 'changeName',
+        name: now.name,
+      },
+      {
+        action: 'changeSlug',
+        slug: now.slug,
+      },
+      {
+        action: 'setDescription',
+        description: now.description,
+      },
+    ])
+    t.end()
+  })
 })

--- a/test/sync/product-sync-variants.spec.js
+++ b/test/sync/product-sync-variants.spec.js
@@ -480,4 +480,92 @@ test('Sync::product::variants', (t) => {
     t.deepEqual(actions, [], 'should not generate any action')
     t.end()
   })
+
+  t.test('should build `setAttribute` action text/ltext attributes ' +
+    'with long text',
+  (t) => {
+    setup()
+
+    const longText = `
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Nunc ultricies fringilla tortor eu egestas.
+    Praesent rhoncus molestie libero, eu tempor sapien placerat id.
+    Donec commodo nunc sed nulla scelerisque, eu pulvinar augue egestas.
+    Donec at leo dolor. Cras at molestie arcu.
+    Sed non fringilla quam, sit amet ultricies massa.
+    Donec luctus tempus erat, ut suscipit elit varius nec.
+    Mauris dolor enim, aliquet sed nulla et, dignissim lobortis augue.
+    Proin pharetra magna eu neque semper tristique sed.
+    `
+
+    const newLongText = `Hello, ${longText}`
+
+    /* eslint-disable max-len */
+    const before = {
+      masterVariant: {
+        id: 1,
+        attributes: [
+          {
+            name: 'text',
+            value: longText,
+          },
+        ],
+      },
+      variants: [
+        {
+          id: 2,
+          attributes: [
+            {
+              name: 'ltext',
+              value: {
+                en: longText,
+              },
+            },
+          ],
+        },
+      ],
+    }
+    const now = {
+      masterVariant: {
+        id: 1,
+        attributes: [
+          {
+            name: 'text',
+            value: newLongText,
+          },
+        ],
+      },
+      variants: [
+        {
+          id: 2,
+          attributes: [
+            {
+              name: 'ltext',
+              value: {
+                en: newLongText,
+              },
+            },
+          ],
+        },
+      ],
+    }
+    /* eslint-enable max-len */
+    const actions = productsSync.buildActions(now, before)
+
+    t.deepEqual(actions, [
+      {
+        action: 'setAttribute',
+        variantId: 1,
+        name: 'text',
+        value: newLongText,
+      },
+      {
+        action: 'setAttribute',
+        variantId: 2,
+        name: 'ltext',
+        value: { en: newLongText },
+      },
+    ])
+    t.end()
+  })
 })


### PR DESCRIPTION
#### Summary
Product actions for variant attributes `ltext` were failing because of missing original object in case of long text diff.

#### TODO
- Tests
    - [x] Unit
