### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "debug": "2.1.x",
     "jsondiffpatch": "0.1.31",
-    "request": "2.54.x"
+    "request": "2.74.0"
   },
   "peerDependencies": {
     "bluebird": ">=2.3.0",


### PR DESCRIPTION
sphere-node-sdk currently has a 3 vulnerable dependency paths, introducing 3 different types of known vulnerabilities.

This PR fixes vulnerable dependencies.
- [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
- [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/sphereio/sphere-node-sdk) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade `debug` dependency as well.

Stay Secure,
The Snyk Team
