### PR TITLE
chore(dependencies): add missing grunt-cli dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - '0.12'
   - '4'
 before_script:
-  - npm install -g grunt-cli
   - ./create_config.sh
 env:
   global:

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "ghooks": "1.0.3",
     "grunt": "0.4.5",
     "grunt-bump": "0.0.13",
+    "grunt-cli": "^1.2.0",
     "grunt-coffeelint": "0.0.13",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-coffee": "0.13.x",


### PR DESCRIPTION
- [x] commit messages are commitizen-friendly
- [ ] code is unit tested
- [ ] code is integration tested
- [ ] public code is documented
- [ ] code is reviewed by at least one person
- [ ] code satisfies linter rules

By adding the missing  dependency we depend on a specific version in the CI environment.
And we don't assume it's globally installed in a development environment.
