### PR TITLE
Rewrite 2.0 auth via HTTP headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage
 dist
 lib
 version.js
+.idea

--- a/test/integration/task-queue.spec.js
+++ b/test/integration/task-queue.spec.js
@@ -83,7 +83,7 @@ test('Integration - TaskQueue token retrieval', t => {
       t.equal(e.body.error_description, 'Please provide valid client ' +
         'credentials using HTTP Basic Authentication.')
       t.deepEqual(e.body.originalRequest, {
-        url: 'https://123:secret@auth.sphere.io/oauth/token',
+        url: 'https://auth.sphere.io/oauth/token',
         method: 'POST',
         body: 'grant_type=client_credentials&scope=manage_project:foo',
       })

--- a/test/utils/auth.spec.js
+++ b/test/utils/auth.spec.js
@@ -11,12 +11,15 @@ test('Utils::authToken', t => {
       },
       host: 'auth.sphere.io',
     })
-    const expectedEndpoint = 'https://123:secret@auth.sphere.io/oauth/token'
+    const expectedEndpoint = 'https://auth.sphere.io/oauth/token'
     const expectedBody = 'grant_type=client_credentials' +
       '&scope=manage_project:foo'
+    // truth is curl 'curl ... --basic --user "123:secret" ... --verbose'
+    const expectedAuthorizationHeader = 'Basic MTIzOnNlY3JldA=='
 
     t.equal(authRequest.endpoint, expectedEndpoint)
     t.equal(authRequest.body, expectedBody)
+    t.equal(authRequest.authorizationHeader, expectedAuthorizationHeader)
     t.end()
   })
 })


### PR DESCRIPTION
This change enables the SDK to be used with clientID and client secret in a browser environment (browser's security rules don't allow `user:pass@host` notation in cross-origin requests). 

It's not working in production yet since the CT auth API does not yet send the necessary CORS headers, but serves as an enabler to motivate fully enabling the API for browser based applications. 

- [ ] commit messages are commitizen-friendly
- [ ] code is unit tested
- [ ] code is integration tested
- [ ] public code is documented
- [ ] code is reviewed by at least one person
- [ ] code satisfies linter rules

