### PR TITLE
Fix updating existing custom fields

### DIFF
--- a/src/coffee/sync/inventory-sync.coffee
+++ b/src/coffee/sync/inventory-sync.coffee
@@ -32,7 +32,7 @@ class InventorySync extends BaseSync
     allActions = []
     allActions.push @_mapActionOrNot 'quantity', => @_utils.actionsMapQuantity(diff, old_obj)
     allActions.push @_mapActionOrNot 'expectedDelivery', => @_utils.actionsMapExpectedDelivery(diff, old_obj)
-    allActions.push @_mapActionOrNot 'custom', => @_utils.actionsMapCustom(diff, old_obj)
+    allActions.push @_mapActionOrNot 'custom', => @_utils.actionsMapCustom(diff, old_obj, new_obj)
     _.flatten allActions
 
 module.exports = InventorySync

--- a/src/coffee/sync/utils/inventory.coffee
+++ b/src/coffee/sync/utils/inventory.coffee
@@ -54,7 +54,7 @@ class InventoryUtils extends BaseUtils
   # old_obj - {Object} The existing inventory
   #
   # Returns {Array} The list of actions, or empty if there are none
-  actionsMapCustom: (diff, old_obj) =>
+  actionsMapCustom: (diff, old_obj, new_obj) =>
     actions = []
     if !diff.custom
       return actions
@@ -79,7 +79,7 @@ class InventoryUtils extends BaseUtils
         {
           action: 'setCustomField'
           name: name
-          value: if Array.isArray(diff.custom.fields[name]) then @getDeltaValue(diff.custom.fields[name]) else diff.custom.fields[name]
+          value: if Array.isArray(diff.custom.fields[name]) then @getDeltaValue(diff.custom.fields[name]) else new_obj.custom.fields[name]
         }
       )
       actions = actions.concat(customFieldsActions)

--- a/src/spec/sync/inventory-sync.spec.coffee
+++ b/src/spec/sync/inventory-sync.spec.coffee
@@ -117,7 +117,10 @@ describe 'InventorySync', ->
             id: '123'
           },
           fields: {
-            nac: 'ho'
+            nac: 'ho',
+            pie: {
+              'nl': 'taart'
+            }
           }
         }
 
@@ -129,7 +132,7 @@ describe 'InventorySync', ->
         update = @sync.buildActions(ieNew, ieOld).getUpdatePayload()
         expect(update.actions[0].action).toBe 'setCustomType'
         expect(update.actions[0].type).toEqual { typeId: 'type', id: '123' }
-        expect(update.actions[0].fields).toEqual { nac: 'ho' }
+        expect(update.actions[0].fields).toEqual { nac: 'ho', pie: {nl:'taart'} }
 
       it 'should set completely new custom type and fields', ->
         ieOld =
@@ -138,7 +141,7 @@ describe 'InventorySync', ->
         update = @sync.buildActions(ieNew, ieOld).getUpdatePayload()
         expect(update.actions[0].action).toBe 'setCustomType'
         expect(update.actions[0].type).toEqual { typeId: 'type', id: '123' }
-        expect(update.actions[0].fields).toEqual { nac: 'ho' }
+        expect(update.actions[0].fields).toEqual { nac: 'ho', pie: {nl: 'taart'} }
 
       it 'should update custom type', ->
         ieOld =
@@ -171,3 +174,24 @@ describe 'InventorySync', ->
         expect(update.actions[0].action).toBe 'setCustomField'
         expect(update.actions[0].name).toBe 'nac'
         expect(update.actions[0].value).toBe 'ho'
+
+      it 'should update localized custom fields', ->
+        ieOld =
+          sku: 'abc'
+          custom: {
+            type: {
+              typeId: 'type',
+              id: '123'
+            },
+            fields: {
+              nac: 'ho',
+              pie: {
+                'nl': 'echt niet'
+              }
+            }
+          }
+
+        update = @sync.buildActions(ieNew, ieOld).getUpdatePayload()
+        expect(update.actions[0].action).toBe 'setCustomField'
+        expect(update.actions[0].name).toBe 'pie'
+        expect(update.actions[0].value).toEqual {'nl': 'taart'}


### PR DESCRIPTION
- [x] commit messages are commitizen-friendly
- [x] code is unit tested
- [x] code is integration tested
- [x] public code is documented
- [x] code is reviewed by at least one person
- [x] code satisfies linter rules

When a custom field already exists use the new object value. This solves the [breaking build](https://travis-ci.org/sphereio/sphere-stock-import/builds/178220591) in stock import. I introduced this bug when just using `diff` in 79e3475aae2569056ebe688938d46d38e8b1a8fc. 🤕 