### PR TITLE
Move sphere-node-utils dependency to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "debug": "2.1.x",
     "jsondiffpatch": "0.1.31",
-    "request": "2.54.x"
+    "request": "2.54.x",
+    "sphere-node-utils": "^0.8.4"
   },
   "peerDependencies": {
     "bluebird": ">=2.3.0",
@@ -57,7 +58,6 @@
     "istanbul": "0.3.x",
     "jasmine-node": "1.14.5",
     "sphere-coffeelint": "git://github.com/sphereio/sphere-coffeelint.git#master",
-    "sphere-node-utils": "^0.8.4",
     "underscore": "1.8.x",
     "underscore-mixins": "0.1.x",
     "validate-commit-msg": "2.0.0"


### PR DESCRIPTION
The released code is using the lib, so an exception is raised whenever the compiled code is used from a fresh npm install. This was introduced in [this commit](https://github.com/sphereio/sphere-node-sdk/commit/2ca67014297aee4b77118b8f0b25aa575992d978) and the dependency was added to devDependecies [here](https://github.com/sphereio/sphere-node-sdk/commit/4227cfee0aeb17f2192ac3a3ffd9e1b1679541f8) to fix the test.

- [ ] commit messages are commitizen-friendly
- [ ] code is unit tested
- [ ] code is integration tested
- [ ] public code is documented
- [ ] code is reviewed by at least one person
- [ ] code satisfies linter rules
