### PR TITLE
fix(product-sync): long text diff error

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "debug": "2.1.x",
-    "jsondiffpatch": "0.1.31",
+    "jsondiffpatch": "0.2.4",
     "request": "2.54.x"
   },
   "peerDependencies": {

--- a/src/coffee/sync/utils/base.coffee
+++ b/src/coffee/sync/utils/base.coffee
@@ -18,7 +18,7 @@ class BaseUtils
       textDiff:
         # if value to diff has a bigger length, a text diffing algorithm is used
         # https://github.com/benjamine/jsondiffpatch/blob/master/docs/deltas.md#text-diffs
-        minLength: 300
+        minLength: 50000
 
   # Internal: Compute the difference between given objects
   diff: (old_obj, new_obj) -> @diffpatcher.diff(old_obj, new_obj)

--- a/src/coffee/sync/utils/base.coffee
+++ b/src/coffee/sync/utils/base.coffee
@@ -17,8 +17,9 @@ class BaseUtils
         includeValueOnMove: false  # value of items moved is not included in deltas
       textDiff:
         # if value to diff has a bigger length, a text diffing algorithm is used
+        # disable the text diffing algorithm by passing an unreachable minimum length
         # https://github.com/benjamine/jsondiffpatch/blob/master/docs/deltas.md#text-diffs
-        minLength: 50000
+        minLength: Infinity
 
   # Internal: Compute the difference between given objects
   diff: (old_obj, new_obj) -> @diffpatcher.diff(old_obj, new_obj)

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -132,9 +132,8 @@ describe 'ProductSync', ->
 
   describe ':: buildActions', ->
 
-    iit 'should build the action update', ->
+    it 'should build the action update', ->
       update = @sync.buildActions(NEW_PRODUCT, OLD_PRODUCT).getUpdatePayload()
-      console.log 'update is ' + JSON.stringify(update.actions[update.actions.length - 1], null, 2)
       expected_update =
         actions: [
           { action: 'removeVariant', id: 4 }

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -22,6 +22,9 @@ OLD_PRODUCT =
       {id: 'p-3', value: {currencyCode: 'EUR', centAmount: 1100}, country: 'DE'},
       {id: 'p-4', value: {currencyCode: 'EUR', centAmount: 1200}, customerGroup: {id: '984a64de-24a4-42c0-868b-da7abfe1c5f6', typeId: 'customer-group'}}
     ]
+    attributes: [
+      { name: 'textAttribute', value: '[{"textAttributeValue":{"fr-CH":"","de-CH":"","it-CH":"","de-DE":"<p><strong>Some random text to make this longer than the value that was in jsondiffpatch.textDiff.minLength = 300. Also this will be badly formatted JSON”</p>","en-GB":"","es-ES":"","fr-FR":""fr-CH":"","fr-FR": "","it-IT": "","nl-NL": "","ru-RU": ""},"testberichte_video": ""}]' }
+    ]
   variants: [
     {
       id: 2
@@ -47,6 +50,7 @@ OLD_PRODUCT =
     de: [{text: 'altes'}, {text: 'zeug'}, {text: 'weg'}]
   }
 
+newTextAttributeValue = '[{"textAttributeValue":{"fr-CH":"","de-CH":"","it-CH":"","de-DE":"<p><strong>Some random text to make this longer than the value that was in jsondiffpatch.textDiff.minLength = 300. This should be now a correctly formatted JSON. However, after jsondiffpatch, it will be changed into a different string”</p>","en-GB":"","es-ES":"","fr-FR":""}}]'
 NEW_PRODUCT =
   id: '123'
   name:
@@ -64,6 +68,9 @@ NEW_PRODUCT =
       {value: {currencyCode: 'EUR', centAmount: 100}},
       {value: {currencyCode: 'EUR', centAmount: 3800}}, # change
       {value: {currencyCode: 'EUR', centAmount: 1100}, country: 'IT'} # change
+    ]
+    attributes: [
+      { name: 'textAttribute', value: newTextAttributeValue }
     ]
   categoryOrderHints:
     myFancyCategoryId: 0.9
@@ -125,8 +132,9 @@ describe 'ProductSync', ->
 
   describe ':: buildActions', ->
 
-    it 'should build the action update', ->
+    iit 'should build the action update', ->
       update = @sync.buildActions(NEW_PRODUCT, OLD_PRODUCT).getUpdatePayload()
+      console.log 'update is ' + JSON.stringify(update.actions[update.actions.length - 1], null, 2)
       expected_update =
         actions: [
           { action: 'removeVariant', id: 4 }
@@ -153,6 +161,7 @@ describe 'ProductSync', ->
           { action: 'addPrice', variantId: 77, price: { value: { currencyCode: 'EUR', centAmount: 4790 }, country: 'AT', customerGroup: { id: 'special-price-id', typeId: 'customer-group' } } }
           { action: 'addPrice', variantId: 77, price: { value: { currencyCode: 'EUR', centAmount: 6559 }, country: 'FR' } }
           { action: 'addPrice', variantId: 77, price: { value: { currencyCode: 'EUR', centAmount: 13118 }, country: 'BE' } }
+          { action: 'setAttribute', variantId : 1, name : 'textAttribute', value : newTextAttributeValue }
         ]
         version: OLD_PRODUCT.version
       expect(update).toEqual expected_update


### PR DESCRIPTION
How to reproduce this error:
1) You have a product with STRING attribute that contains invalid JSON. The length of this String is long enough so that jsondiffpatch uses text diff algorithm
2) You want to update this String attribute with the valid JSON. This valid JSON is also long enough.
3) As the result, the valid String attribute is changed into invalid JSON String.

I discovered there's an error inside the algorithm itself. The fastest way is to disable the usage of the algorithm. However, it's not possible to disable it, as it will fall back to default value 60: https://github.com/benjamine/jsondiffpatch/blob/0fe51f884695b02179e7a836a82b4241243d78cb/src/filters/texts.js#L55. So for now I increase it to bigger value to prevent using this algorithm.

- [ ] commit messages are commitizen-friendly
- [ ] code is unit tested
- [ ] code is integration tested
- [ ] public code is documented
- [ ] code is reviewed by at least one person
- [ ] code satisfies linter rules
