### PR TITLE
fix(product-sync): set attributes before add variants

### DIFF
--- a/src/coffee/sync/product-sync.coffee
+++ b/src/coffee/sync/product-sync.coffee
@@ -37,12 +37,17 @@ class ProductSync extends BaseSync
     super new_obj, old_obj
 
   _doMapActions: (diff, new_obj, old_obj) ->
+    variantActions = @_mapActionOrNot 'variants', => @_utils.actionsMapVariants(diff, old_obj, new_obj)
+    removeVariantActions = variantActions.filter (action) -> action.action is 'removeVariant'
+    addVariantActions = variantActions.filter (action) -> action.action is 'addVariant'
+
     allActions = []
-    allActions.push @_mapActionOrNot 'variants', => @_utils.actionsMapVariants(diff, old_obj, new_obj)
+    allActions.push removeVariantActions
+    allActions.push @_mapActionOrNot 'attributes', => @_utils.actionsMapAttributes(diff, old_obj, new_obj, @sameForAllAttributeNames)
+    allActions.push addVariantActions
     allActions.push @_mapActionOrNot 'base', => @_utils.actionsMapBase(diff, old_obj)
     allActions.push @_mapActionOrNot 'references', => @_utils.actionsMapReferences(diff, old_obj, new_obj)
     allActions.push @_mapActionOrNot 'prices', => @_utils.actionsMapPrices(diff, old_obj, new_obj)
-    allActions.push @_mapActionOrNot 'attributes', => @_utils.actionsMapAttributes(diff, old_obj, new_obj, @sameForAllAttributeNames)
     allActions.push @_mapActionOrNot 'images', => @_utils.actionsMapImages(diff, old_obj, new_obj)
     allActions.push @_mapActionOrNot 'categories', => @_utils.actionsMapCategories(diff)
     _.flatten allActions

--- a/src/coffee/sync/product-sync.coffee
+++ b/src/coffee/sync/product-sync.coffee
@@ -41,13 +41,11 @@ class ProductSync extends BaseSync
     # has old value of the sameForAll attribute. That's why it's necessary to update the attributes
     # before adding new variant
     variantActions = @_mapActionOrNot 'variants', => @_utils.actionsMapVariants(diff, old_obj, new_obj)
-    removeVariantActions = variantActions.filter (action) -> action.action is 'removeVariant'
-    addVariantActions = variantActions.filter (action) -> action.action is 'addVariant'
 
     allActions = []
-    allActions.push removeVariantActions
+    allActions.push variantActions.filter (action) -> action.action is 'removeVariant'
     allActions.push @_mapActionOrNot 'attributes', => @_utils.actionsMapAttributes(diff, old_obj, new_obj, @sameForAllAttributeNames)
-    allActions.push addVariantActions
+    allActions.push variantActions.filter (action) -> action.action is 'addVariant'
     allActions.push @_mapActionOrNot 'base', => @_utils.actionsMapBase(diff, old_obj)
     allActions.push @_mapActionOrNot 'references', => @_utils.actionsMapReferences(diff, old_obj, new_obj)
     allActions.push @_mapActionOrNot 'prices', => @_utils.actionsMapPrices(diff, old_obj, new_obj)

--- a/src/coffee/sync/product-sync.coffee
+++ b/src/coffee/sync/product-sync.coffee
@@ -37,6 +37,9 @@ class ProductSync extends BaseSync
     super new_obj, old_obj
 
   _doMapActions: (diff, new_obj, old_obj) ->
+    # New variant can have attributes with new values and this can cause conflict if the product still
+    # has old value of the sameForAll attribute. That's why it's necessary to update the attributes
+    # before adding new variant
     variantActions = @_mapActionOrNot 'variants', => @_utils.actionsMapVariants(diff, old_obj, new_obj)
     removeVariantActions = variantActions.filter (action) -> action.action is 'removeVariant'
     addVariantActions = variantActions.filter (action) -> action.action is 'addVariant'

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -219,3 +219,67 @@ describe 'ProductSync', ->
         ]
         version: oldProduct.version
       expect(update).toEqual expected_update
+
+    it 'should create update actions in correct order', ->
+      oldProduct =
+        id: '123'
+        version: 1
+        masterVariant:
+          id: 1
+          sku: 'v1'
+          attributes: [{name: 'foo', value: 'bar'}]
+        variants: [
+          { id: 2, sku: 'v2', attributes: [{name: 'foo', value: 'qux'}] }
+          { id: 3, sku: 'v3', attributes: [{name: 'foo', value: 'baz'}] }
+        ]
+
+      newProduct =
+        id: '123'
+        masterVariant:
+          sku: 'v1'
+          attributes: [
+            { name: 'foo', value: 'new value' },
+            { name: 'new attribute', value: 'sameForAllAttribute' }
+          ]
+        variants: [
+          { id: 2, sku: 'v2', attributes: [{name: 'foo', value: 'another value'}] }
+          { id: 4, sku: 'v4', attributes: [{name: 'foo', value: 'yet another'}] }
+        ]
+      update = @sync.buildActions(newProduct, oldProduct, ['new attribute']).getUpdatePayload()
+
+      expected_update =
+        actions: [
+          {
+            action: 'removeVariant',
+            id: 3
+          },
+          {
+            action: 'setAttribute',
+            variantId: 1,
+            name: 'foo',
+            value: 'new value'
+          },
+          {
+            action: 'setAttributeInAllVariants',
+            name: 'new attribute',
+            value: 'sameForAllAttribute'
+          },
+          {
+            action: 'setAttribute',
+            variantId: 2,
+            name: 'foo',
+            value: 'another value'
+          },
+          {
+            action: 'addVariant',
+            sku: 'v4',
+            attributes: [
+              {
+                name: 'foo',
+                value: 'yet another'
+              }
+            ]
+          }
+        ],
+        version: oldProduct.version
+      expect(update).toEqual expected_update

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -193,10 +193,10 @@ describe 'ProductSync', ->
       update = @sync.buildActions(newProduct, oldProduct).getUpdatePayload()
       expected_update =
         actions: [
-          { action: 'addVariant', sku: 'v4', attributes: [{ name: 'foo', value: 'i dont care' }] }
           { action: 'setAttribute', variantId: 1, name: 'foo', value: 'new value' }
           { action: 'setAttribute', variantId: 2, name: 'foo', value: 'another value' }
           { action: 'setAttribute', variantId: 3, name: 'foo', value: 'yet another' }
+          { action: 'addVariant', sku: 'v4', attributes: [{ name: 'foo', value: 'i dont care' }] }
         ]
         version: oldProduct.version
       expect(update).toEqual expected_update

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -247,39 +247,10 @@ describe 'ProductSync', ->
         ]
       update = @sync.buildActions(newProduct, oldProduct, ['new attribute']).getUpdatePayload()
 
-      expected_update =
-        actions: [
-          {
-            action: 'removeVariant',
-            id: 3
-          },
-          {
-            action: 'setAttribute',
-            variantId: 1,
-            name: 'foo',
-            value: 'new value'
-          },
-          {
-            action: 'setAttributeInAllVariants',
-            name: 'new attribute',
-            value: 'sameForAllAttribute'
-          },
-          {
-            action: 'setAttribute',
-            variantId: 2,
-            name: 'foo',
-            value: 'another value'
-          },
-          {
-            action: 'addVariant',
-            sku: 'v4',
-            attributes: [
-              {
-                name: 'foo',
-                value: 'yet another'
-              }
-            ]
-          }
-        ],
-        version: oldProduct.version
-      expect(update).toEqual expected_update
+      actionNames = update.actions.map((a) -> a.action)
+      setAttrPos = actionNames.indexOf('setAttributeInAllVariants')
+      removeVariantPos = actionNames.indexOf('removeVariant')
+      addVariantPos = actionNames.indexOf('addVariant')
+
+      expect(setAttrPos).toBeGreaterThan removeVariantPos
+      expect(setAttrPos).toBeLessThan addVariantPos


### PR DESCRIPTION
Product sync updates needs to set attributes before adding new variants. The problem is when you have setAttributeInAllVariants for same for all attribute and a new variant, you need to change the same for all value for old variants first before you can create the new variant.

- [ ] commit messages are commitizen-friendly
- [ ] code is unit tested
- [ ] code is integration tested
- [ ] public code is documented
- [ ] code is reviewed by at least one person
- [ ] code satisfies linter rules
