### PR TITLE
fix(inventory): change quantity instead of calculating the difference

### DIFF
--- a/src/coffee/services/inventory-entries.coffee
+++ b/src/coffee/services/inventory-entries.coffee
@@ -13,7 +13,7 @@ BaseService = require './base'
 #       version: result.body.version
 #       actions: [
 #         {
-#           action: 'addQuantity'
+#           action: 'changeQuantity'
 #           quantity: 10
 #         }
 #       ]

--- a/src/coffee/sync/inventory-sync.coffee
+++ b/src/coffee/sync/inventory-sync.coffee
@@ -30,7 +30,7 @@ class InventorySync extends BaseSync
 
   _doMapActions: (diff, new_obj, old_obj) ->
     allActions = []
-    allActions.push @_mapActionOrNot 'quantity', => @_utils.actionsMapQuantity(diff, old_obj)
+    allActions.push @_mapActionOrNot 'quantity', => @_utils.actionsMapQuantity(diff)
     allActions.push @_mapActionOrNot 'expectedDelivery', => @_utils.actionsMapExpectedDelivery(diff, old_obj)
     allActions.push @_mapActionOrNot 'custom', => @_utils.actionsMapCustom(diff, old_obj, new_obj)
     _.flatten allActions

--- a/src/coffee/sync/utils/inventory.coffee
+++ b/src/coffee/sync/utils/inventory.coffee
@@ -18,12 +18,9 @@ class InventoryUtils extends BaseUtils
         newVal = diff.quantityOnStock[1]
         diffVal = newVal - oldVal
         a =
-          quantity: Math.abs diffVal
-        if diffVal > 0
-          a.action = 'addQuantity'
-          actions.push a
-        else if diffVal < 0
-          a.action = 'removeQuantity'
+          quantity: newVal
+        if diffVal
+          a.action = 'changeQuantity'
           actions.push a
     actions
 

--- a/src/coffee/sync/utils/inventory.coffee
+++ b/src/coffee/sync/utils/inventory.coffee
@@ -16,10 +16,10 @@ class InventoryUtils extends BaseUtils
         oldVal = diff.quantityOnStock[0]
         newVal = diff.quantityOnStock[1]
         diffVal = newVal - oldVal
-        a =
-          quantity: newVal
         if diffVal
-          a.action = 'changeQuantity'
+          a =
+            action: 'changeQuantity'
+            quantity: newVal
           actions.push a
     actions
 

--- a/src/coffee/sync/utils/inventory.coffee
+++ b/src/coffee/sync/utils/inventory.coffee
@@ -7,10 +7,9 @@ class InventoryUtils extends BaseUtils
   # Private: map inventory quantities
   #
   # diff - {Object} The result of diff from `jsondiffpatch`
-  # old_obj - {Object} The existing inventory
   #
   # Returns {Array} The list of actions, or empty if there are none
-  actionsMapQuantity: (diff, old_obj) ->
+  actionsMapQuantity: (diff) ->
     actions = []
     if diff.quantityOnStock
       if _.isArray(diff.quantityOnStock) and _.size(diff.quantityOnStock) is 2

--- a/src/spec/errors.spec.coffee
+++ b/src/spec/errors.spec.coffee
@@ -57,7 +57,7 @@ describe 'Errors', ->
           payload:
             version: 1
             actions: [
-              {action: 'addQuantity', quantity: 10 }
+              {action: 'changeQuantity', quantity: 10 }
             ]
       ce = new Errors.SphereHttpError[error.name] 'Ooops', expectedBody
 

--- a/src/spec/sync/inventory-sync.spec.coffee
+++ b/src/spec/sync/inventory-sync.spec.coffee
@@ -27,7 +27,7 @@ describe 'InventorySync', ->
       update = @sync.config(opts).buildActions(newInventory, oldInventory).getUpdatePayload()
       expected_update =
         actions: [
-          { action: 'removeQuantity', quantity: 8 }
+          { action: 'changeQuantity', quantity: 2 }
         ]
         version: oldInventory.version
       expect(update).toEqual expected_update
@@ -53,8 +53,8 @@ describe 'InventorySync', ->
         quantityOnStock: 9
       update = @sync.buildActions(ieNew, ieOld).getUpdatePayload()
       expect(update).toBeDefined()
-      expect(update.actions[0].action).toBe 'addQuantity'
-      expect(update.actions[0].quantity).toBe 68
+      expect(update.actions[0].action).toBe 'changeQuantity'
+      expect(update.actions[0].quantity).toBe 77
 
     it 'less quantity', ->
       ieNew =
@@ -65,8 +65,8 @@ describe 'InventorySync', ->
         quantityOnStock: 9
       update = @sync.buildActions(ieNew, ieOld).getUpdatePayload()
       expect(update).toBeDefined()
-      expect(update.actions[0].action).toBe 'removeQuantity'
-      expect(update.actions[0].quantity).toBe 2
+      expect(update.actions[0].action).toBe 'changeQuantity'
+      expect(update.actions[0].quantity).toBe 7
 
     it 'should add expectedDelivery', ->
       ieNew =

--- a/src/spec/sync/utils/inventory.spec.coffee
+++ b/src/spec/sync/utils/inventory.spec.coffee
@@ -27,7 +27,7 @@ describe 'InventoryUtils', ->
 
       expected_update =
         [
-          { action: 'addQuantity', quantity: 3 }
+          { action: 'changeQuantity', quantity: 10 }
         ]
       expect(update).toEqual expected_update
 

--- a/src/spec/sync/utils/inventory.spec.coffee
+++ b/src/spec/sync/utils/inventory.spec.coffee
@@ -23,7 +23,7 @@ describe 'InventoryUtils', ->
       inventoryChanged.quantityOnStock = 10
 
       delta = @utils.diff(@inventory, inventoryChanged)
-      update = @utils.actionsMapQuantity(delta, inventoryChanged)
+      update = @utils.actionsMapQuantity(delta)
 
       expected_update =
         [


### PR DESCRIPTION
The main reason for this change is it's easier to repeat the request in case of concurrent modification error. With the old diff calculation, it's necessary to refetch the inventories and recalculate the diff. With this new change, it's enough to change the version number and repeat the request.

- [ ] commit messages are commitizen-friendly
- [ ] code is unit tested
- [ ] code is integration tested
- [ ] public code is documented
- [ ] code is reviewed by at least one person
- [ ] code satisfies linter rules