### PR TITLE
Fix/long text diff error

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "debug": "2.1.x",
-    "jsondiffpatch": "0.1.31",
+    "jsondiffpatch": "0.2.4",
     "request": "2.54.x"
   },
   "peerDependencies": {

--- a/src/coffee/sync/utils/base.coffee
+++ b/src/coffee/sync/utils/base.coffee
@@ -19,7 +19,7 @@ class BaseUtils
         # if value to diff has a bigger length, a text diffing algorithm is used
         # disable the text diffing algorithm by passing an unreachable minimum length
         # https://github.com/benjamine/jsondiffpatch/blob/master/docs/deltas.md#text-diffs
-        minLength: Infinity
+        minLength: 300
 
   # Internal: Compute the difference between given objects
   diff: (old_obj, new_obj) -> @diffpatcher.diff(old_obj, new_obj)
@@ -28,7 +28,7 @@ class BaseUtils
   patch: (obj, delta) -> @diffpatcher.patch(obj, delta)
 
   # Internal: Pick correct value based on delta format
-  getDeltaValue: (arr, obj) ->
+  getDeltaValue: (arr, originalObject) ->
     throw new Error 'Expected array to extract delta value' unless _.isArray(arr)
     size = arr.length
     switch size
@@ -40,9 +40,9 @@ class BaseUtils
         if arr[2] is 0 # delete
           undefined
         else if arr[2] is 2 # text diff
-          throw new Error 'Cannot apply patch to long text diff. Missing original object.' unless obj
+          throw new Error 'Cannot apply patch to long text diff. Missing original object.' unless originalObject
           # try to apply patch to given object based on delta value
-          jsondiffpatch.patch(obj, arr)
+          jsondiffpatch.patch(originalObject, arr)
         else if arr[2] is 3 # array move
           throw new Error 'Detected an array move, it should not happen as includeValueOnMove should be set to false'
         else

--- a/src/coffee/sync/utils/base.coffee
+++ b/src/coffee/sync/utils/base.coffee
@@ -18,7 +18,7 @@ class BaseUtils
       textDiff:
         # if value to diff has a bigger length, a text diffing algorithm is used
         # https://github.com/benjamine/jsondiffpatch/blob/master/docs/deltas.md#text-diffs
-        minLength: 300
+        minLength: 50000
 
   # Internal: Compute the difference between given objects
   diff: (old_obj, new_obj) -> @diffpatcher.diff(old_obj, new_obj)

--- a/src/coffee/sync/utils/base.coffee
+++ b/src/coffee/sync/utils/base.coffee
@@ -17,7 +17,6 @@ class BaseUtils
         includeValueOnMove: false  # value of items moved is not included in deltas
       textDiff:
         # if value to diff has a bigger length, a text diffing algorithm is used
-        # disable the text diffing algorithm by passing an unreachable minimum length
         # https://github.com/benjamine/jsondiffpatch/blob/master/docs/deltas.md#text-diffs
         minLength: 300
 

--- a/src/coffee/sync/utils/base.coffee
+++ b/src/coffee/sync/utils/base.coffee
@@ -17,8 +17,9 @@ class BaseUtils
         includeValueOnMove: false  # value of items moved is not included in deltas
       textDiff:
         # if value to diff has a bigger length, a text diffing algorithm is used
+        # disable the text diffing algorithm by passing an unreachable minimum length
         # https://github.com/benjamine/jsondiffpatch/blob/master/docs/deltas.md#text-diffs
-        minLength: 50000
+        minLength: Infinity
 
   # Internal: Compute the difference between given objects
   diff: (old_obj, new_obj) -> @diffpatcher.diff(old_obj, new_obj)

--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -470,54 +470,54 @@ class ProductUtils extends BaseUtils
         imageUrl: image.url
     action
 
-  _buildSetAttributeAction: (diffed_value, old_variant, attribute, sameForAllAttributeNames) ->
-    return unless attribute
-    if attribute
+  _buildSetAttributeAction: (diffed_value, old_variant, newAttribute, sameForAllAttributeNames) ->
+    return unless newAttribute
+    if newAttribute
       action =
         action: 'setAttribute'
         variantId: old_variant.id
-        name: attribute.name
+        name: newAttribute.name
+      oldAttribute = _.find old_variant.attributes, (attrib) ->
+        attrib.name is newAttribute.name
 
-      if _.contains(sameForAllAttributeNames, attribute.name)
+      if _.contains(sameForAllAttributeNames, newAttribute.name)
         action.action = 'setAttributeInAllVariants'
         delete action.variantId
 
       if _.isArray(diffed_value)
-        action.value = @getDeltaValue(diffed_value, attribute.value)
+        action.value = @getDeltaValue(diffed_value, oldAttribute.value)
       else
         # LText: value: {en: "", de: ""}
         # Money: value: {centAmount: 123, currencyCode: ""}
         # *: value: ""
         if _.isString(diffed_value)
           # normal
-          action.value = @getDeltaValue(diffed_value, attribute.value)
+          action.value = @getDeltaValue(diffed_value, oldAttribute.value)
         else if diffed_value.centAmount
           # Money
           if diffed_value.centAmount
             centAmount = @getDeltaValue(diffed_value.centAmount)
           else
-            centAmount = attribute.value.centAmount
+            centAmount = newAttribute.value.centAmount
           if diffed_value.currencyCode
             currencyCode = @getDeltaValue(diffed_value.currencyCode)
           else
-            currencyCode = attribute.value.currencyCode
+            currencyCode = newAttribute.value.currencyCode
           action.value =
             centAmount: centAmount
             currencyCode: currencyCode
         else if _.isObject(diffed_value)
           if _.has(diffed_value, '_t') and diffed_value['_t'] is 'a'
             # set-typed attribute
-            _.each attribute.value, (v) ->
+            _.each newAttribute.value, (v) ->
               delete v._MATCH_CRITERIA unless _.isString(v)
-            action.value = attribute.value
+            action.value = newAttribute.value
           else
             # LText
-            attrib = _.find old_variant.attributes, (attrib) ->
-              attrib.name is attribute.name
-            text = _.extend {}, attrib?.value
+            text = _.extend {}, oldAttribute?.value
             _.each diffed_value, (localValue, lang) =>
               # make sure to support long text diff patching
-              text[lang] = @getDeltaValue(localValue, attrib.value[lang])
+              text[lang] = @getDeltaValue(localValue, oldAttribute.value[lang])
             action.value = text
     action
 

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -132,9 +132,8 @@ describe 'ProductSync', ->
 
   describe ':: buildActions', ->
 
-    iit 'should build the action update', ->
+    it 'should build the action update', ->
       update = @sync.buildActions(NEW_PRODUCT, OLD_PRODUCT).getUpdatePayload()
-      console.log 'update is ' + JSON.stringify(update.actions[update.actions.length - 1], null, 2)
       expected_update =
         actions: [
           { action: 'removeVariant', id: 4 }

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -22,6 +22,9 @@ OLD_PRODUCT =
       {id: 'p-3', value: {currencyCode: 'EUR', centAmount: 1100}, country: 'DE'},
       {id: 'p-4', value: {currencyCode: 'EUR', centAmount: 1200}, customerGroup: {id: '984a64de-24a4-42c0-868b-da7abfe1c5f6', typeId: 'customer-group'}}
     ]
+    attributes: [
+      { name: 'textAttribute', value: '[{"textAttributeValue":{"fr-CH":"","de-CH":"","it-CH":"","de-DE":"<p><strong>Some random text to make this longer than the value that was in jsondiffpatch.textDiff.minLength = 300. Also this will be badly formatted JSON”</p>","en-GB":"","es-ES":"","fr-FR":""fr-CH":"","fr-FR": "","it-IT": "","nl-NL": "","ru-RU": ""},"testberichte_video": ""}]' }
+    ]
   variants: [
     {
       id: 2
@@ -47,6 +50,7 @@ OLD_PRODUCT =
     de: [{text: 'altes'}, {text: 'zeug'}, {text: 'weg'}]
   }
 
+newTextAttributeValue = '[{"textAttributeValue":{"fr-CH":"","de-CH":"","it-CH":"","de-DE":"<p><strong>Some random text to make this longer than the value that was in jsondiffpatch.textDiff.minLength = 300. This should be now a correctly formatted JSON. However, after jsondiffpatch, it will be changed into a different string”</p>","en-GB":"","es-ES":"","fr-FR":""}}]'
 NEW_PRODUCT =
   id: '123'
   name:
@@ -64,6 +68,9 @@ NEW_PRODUCT =
       {value: {currencyCode: 'EUR', centAmount: 100}},
       {value: {currencyCode: 'EUR', centAmount: 3800}}, # change
       {value: {currencyCode: 'EUR', centAmount: 1100}, country: 'IT'} # change
+    ]
+    attributes: [
+      { name: 'textAttribute', value: newTextAttributeValue }
     ]
   categoryOrderHints:
     myFancyCategoryId: 0.9
@@ -125,8 +132,9 @@ describe 'ProductSync', ->
 
   describe ':: buildActions', ->
 
-    it 'should build the action update', ->
+    iit 'should build the action update', ->
       update = @sync.buildActions(NEW_PRODUCT, OLD_PRODUCT).getUpdatePayload()
+      console.log 'update is ' + JSON.stringify(update.actions[update.actions.length - 1], null, 2)
       expected_update =
         actions: [
           { action: 'removeVariant', id: 4 }
@@ -153,6 +161,7 @@ describe 'ProductSync', ->
           { action: 'addPrice', variantId: 77, price: { value: { currencyCode: 'EUR', centAmount: 4790 }, country: 'AT', customerGroup: { id: 'special-price-id', typeId: 'customer-group' } } }
           { action: 'addPrice', variantId: 77, price: { value: { currencyCode: 'EUR', centAmount: 6559 }, country: 'FR' } }
           { action: 'addPrice', variantId: 77, price: { value: { currencyCode: 'EUR', centAmount: 13118 }, country: 'BE' } }
+          { action: 'setAttribute', variantId : 1, name : 'textAttribute', value : newTextAttributeValue }
         ]
         version: OLD_PRODUCT.version
       expect(update).toEqual expected_update

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -22,9 +22,6 @@ OLD_PRODUCT =
       {id: 'p-3', value: {currencyCode: 'EUR', centAmount: 1100}, country: 'DE'},
       {id: 'p-4', value: {currencyCode: 'EUR', centAmount: 1200}, customerGroup: {id: '984a64de-24a4-42c0-868b-da7abfe1c5f6', typeId: 'customer-group'}}
     ]
-    attributes: [
-      { name: 'textAttribute', value: '[{"textAttributeValue":{"fr-CH":"","de-CH":"","it-CH":"","de-DE":"<p><strong>Some random text to make this longer than the value that was in jsondiffpatch.textDiff.minLength = 300. Also this will be badly formatted JSON”</p>","en-GB":"","es-ES":"","fr-FR":""fr-CH":"","fr-FR": "","it-IT": "","nl-NL": "","ru-RU": ""},"testberichte_video": ""}]' }
-    ]
   variants: [
     {
       id: 2
@@ -50,7 +47,6 @@ OLD_PRODUCT =
     de: [{text: 'altes'}, {text: 'zeug'}, {text: 'weg'}]
   }
 
-newTextAttributeValue = '[{"textAttributeValue":{"fr-CH":"","de-CH":"","it-CH":"","de-DE":"<p><strong>Some random text to make this longer than the value that was in jsondiffpatch.textDiff.minLength = 300. This should be now a correctly formatted JSON. However, after jsondiffpatch, it will be changed into a different string”</p>","en-GB":"","es-ES":"","fr-FR":""}}]'
 NEW_PRODUCT =
   id: '123'
   name:
@@ -77,9 +73,6 @@ NEW_PRODUCT =
           }
         }
       }
-    ]
-    attributes: [
-      { name: 'textAttribute', value: newTextAttributeValue }
     ]
   categoryOrderHints:
     myFancyCategoryId: 0.9
@@ -170,7 +163,6 @@ describe 'ProductSync', ->
           { action: 'addPrice', variantId: 77, price: { value: { currencyCode: 'EUR', centAmount: 4790 }, country: 'AT', customerGroup: { id: 'special-price-id', typeId: 'customer-group' } } }
           { action: 'addPrice', variantId: 77, price: { value: { currencyCode: 'EUR', centAmount: 6559 }, country: 'FR' } }
           { action: 'addPrice', variantId: 77, price: { value: { currencyCode: 'EUR', centAmount: 13118 }, country: 'BE' } }
-          { action: 'setAttribute', variantId : 1, name : 'textAttribute', value : newTextAttributeValue }
         ]
         version: OLD_PRODUCT.version
       expect(update).toEqual expected_update

--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -1104,6 +1104,10 @@ describe 'ProductUtils', ->
               value: '//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-1.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-2.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-4.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-5.jpg'
             },
             {
+              name: 'textAttribute',
+              value: '[{"textAttributeValue":{"fr-CH":"","de-CH":"","it-CH":"","de-DE":"<p><strong>Some random text to make this longer than the value that was in jsondiffpatch.textDiff.minLength = 300. This should be now a correctly formatted JSON. However, after jsondiffpatch, it will be changed into a different string”</p>","en-GB":"","es-ES":"","fr-FR":""}}]'
+            },
+            {
               name: 'localized_images',
               value: {
                 en: '//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-1.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-2.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-4.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-5.jpg'
@@ -1123,6 +1127,10 @@ describe 'ProductUtils', ->
               value: 'http://images.luxodo.com/html/zoom/luxodo/p-HARJPUL101601-1/2000/2000/p-HARJPUL101601-1.jpg;http://images.luxodo.com/html/zoom/luxodo/p-HARJPUL101601-2/2000/2000/p-HARJPUL101601-2.jpg;http://images.luxodo.com/html/zoom/luxodo/p-HARJPUL101601-4/2000/2000/p-HARJPUL101601-4.jpg;http://images.luxodo.com/html/zoom/luxodo/p-HARJPUL101601-5/2000/2000/p-HARJPUL101601-5.jpg'
             },
             {
+              name: 'textAttribute',
+              value: '[{"textAttributeValue":{"fr-CH":"","de-CH":"","it-CH":"","de-DE":"<p><strong>Some random text to make this longer than the value that was in jsondiffpatch.textDiff.minLength = 300. Also this will be badly formatted JSON”</p>","en-GB":"","es-ES":"","fr-FR":""fr-CH":"","fr-FR": "","it-IT": "","nl-NL": "","ru-RU": ""},"testberichte_video": ""}]'
+            },
+            {
               name: 'localized_images',
               value: {
                 en: 'http://images.luxodo.com/html/zoom/luxodo/p-HARJPUL101601-1/2000/2000/p-HARJPUL101601-1.jpg;http://images.luxodo.com/html/zoom/luxodo/p-HARJPUL101601-2/2000/2000/p-HARJPUL101601-2.jpg;http://images.luxodo.com/html/zoom/luxodo/p-HARJPUL101601-4/2000/2000/p-HARJPUL101601-4.jpg;http://images.luxodo.com/html/zoom/luxodo/p-HARJPUL101601-5/2000/2000/p-HARJPUL101601-5.jpg'
@@ -1138,6 +1146,7 @@ describe 'ProductUtils', ->
       expected_update =
         [
           { action: 'setAttribute', variantId: 1, name: 'images', value: '//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-1.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-2.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-4.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-5.jpg' },
+          { action: 'setAttribute', variantId: 1, name: 'textAttribute', value: '[{"textAttributeValue":{"fr-CH":"","de-CH":"","it-CH":"","de-DE":"<p><strong>Some random text to make this longer than the value that was in jsondiffpatch.textDiff.minLength = 300. This should be now a correctly formatted JSON. However, after jsondiffpatch, it will be changed into a different string”</p>","en-GB":"","es-ES":"","fr-FR":""}}]' },
           { action: 'setAttribute', variantId: 1, name: 'localized_images', value: { en: '//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-1.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-2.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-4.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-5.jpg' } }
         ]
       expect(update).toEqual expected_update


### PR DESCRIPTION
This PR fixes the wrong value returned by the jsondiffpatch. The bug was that in order to call `jsondiffpatch.patch()`, you need to pass an original value and the diff. However, the code passes the new value and the diff, which causes the jsondiffpatch to return wrong value after patch.

Previous PR that was closed because the solution was not correct:
https://github.com/sphereio/sphere-node-sdk/pull/197

- [ ] commit messages are commitizen-friendly
- [ ] code is unit tested
- [ ] code is integration tested
- [ ] public code is documented
- [ ] code is reviewed by at least one person
- [ ] code satisfies linter rules
