### PR TITLE
fix(product): don't modify original product when building variant attributes

### DIFF
--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -562,8 +562,11 @@ class ProductUtils extends BaseUtils
               return
             deltaValue = @getDeltaValue(value)
             unless deltaValue
-              deltaValue = value[0]
-              delete deltaValue.value
+              # Taken from https://github.com/commercetools/nodejs/blob/ab8edfb41bdc7d429f20554d3d8a45ef251228f8/packages/sync-actions/src/product-actions.js#L286
+              if (value[0] && value[0].name)
+                deltaValue = { name: value[0].name }
+              else
+                deltaValue = undefined
             id = old_variant.id
             setAction = @_buildNewSetAttributeAction(id, deltaValue, sameForAllAttributeNames)
             actions.push setAction if setAction

--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -1187,9 +1187,15 @@ describe 'ProductUtils', ->
       cloneOfOriginalProduct = _.deepClone(originalProduct)
 
       delta = @utils.diff originalProduct, newProduct
-      @utils.actionsMapAttributes delta, originalProduct, newProduct
+      update = @utils.actionsMapAttributes delta, originalProduct, newProduct
 
+      expected_update =
+        [
+          { action: 'setAttribute', variantId: 1, name: 'testAttribute1', value: false },
+          { action: 'setAttribute', variantId: 1, name: 'testAttribute2' }
+        ]
       expect(cloneOfOriginalProduct.masterVariant.attributes).toEqual originalProduct.masterVariant.attributes
+      expect(update).toEqual expected_update
 
   describe ':: actionsMapImages', ->
 

--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -1151,6 +1151,46 @@ describe 'ProductUtils', ->
         ]
       expect(update).toEqual expected_update
 
+    it 'should not modify original attributes', ->
+      newProduct =
+        masterVariant:
+          id: 1
+          sku: 'test_sku_1'
+          attributes: [
+            {
+              name: 'testAttribute1',
+              value: false
+            }
+          ]
+        variants: [
+          id: 2
+          sku: 'test_sku_2'
+          attributes: [
+            {
+              name: 'testAttribute1',
+              value: false
+            }
+          ]
+        ]
+
+      originalProduct =
+        masterVariant:
+          id: 1
+          sku: 'test_sku_1'
+          attributes: [
+            {
+              name: 'testAttribute2',
+              value: 'testValue'
+            }
+          ]
+
+      cloneOfOriginalProduct = _.deepClone(originalProduct)
+
+      delta = @utils.diff originalProduct, newProduct
+      @utils.actionsMapAttributes delta, originalProduct, newProduct
+
+      expect(cloneOfOriginalProduct.masterVariant.attributes).toEqual originalProduct.masterVariant.attributes
+
   describe ':: actionsMapImages', ->
 
     it 'should build actions for images', ->


### PR DESCRIPTION
The old code deleted the attribute of an object that was part of the original product attribute. So instead of correct format:
```js
{ name: 'attributeName', value: 'attributeValue' }
```
we had:
```js
{ name: 'attributeName' }
```
in the variant attributes of the original product. I fixed it by replacing the old code with the one from the new node SDK.
https://github.com/commercetools/nodejs/blob/ab8edfb41bdc7d429f20554d3d8a45ef251228f8/packages/sync-actions/src/product-actions.js#L286

- [ ] commit messages are commitizen-friendly
- [ ] code is unit tested
- [ ] code is integration tested
- [ ] public code is documented
- [ ] code is reviewed by at least one person
- [ ] code satisfies linter rules
