### PR TITLE
fix(product): dont create setAttribute action when the product attribute did not change

### DIFF
--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -1151,6 +1151,57 @@ describe 'ProductUtils', ->
         ]
       expect(update).toEqual expected_update
 
+    it 'should not create update action if attribute is not changed', ->
+      newProduct =
+        masterVariant:
+          sku: 'TEST MASTER VARIANT'
+          attributes: [
+            {
+              'name': 'test_attribute',
+              'value': [
+                {
+                  'label': {
+                    'de': 'grün'
+                  },
+                  'key': 'GN'
+                },
+                {
+                  'label': {
+                    'de': 'schwarz'
+                  },
+                  'key': 'SW'
+                }
+              ]
+            }
+          ]
+
+      originalProduct =
+        masterVariant:
+          sku: 'TEST MASTER VARIANT'
+          attributes: [
+            {
+              name: 'test_attribute',
+              value: [
+                {
+                  label: {
+                    'de': 'schwarz'
+                  },
+                  key: 'SW'
+                },
+                {
+                  label: {
+                    'de': 'grün'
+                  },
+                  key: 'GN'
+                }
+              ]
+            }
+          ]
+
+      delta = @utils.diff originalProduct, newProduct
+      update = @utils.actionsMapAttributes delta, originalProduct, newProduct
+      expect(update.length).toBe(0)
+
   describe ':: actionsMapImages', ->
 
     it 'should build actions for images', ->


### PR DESCRIPTION
When the new product attribute contains same elements as the old product attribute, but only in different order, the update action is created and sent to the API. However, since nothing was changed, an error is returned from the API:

BadRequest: A duplicate combination of the variant values (sku, key, images, prices, attributes) exists.

Solution: check if the product attribute has really changed or the elements of the attribute are just in a different order.

- [ ] commit messages are commitizen-friendly
- [ ] code is unit tested
- [ ] code is integration tested
- [ ] public code is documented
- [ ] code is reviewed by at least one person
- [ ] code satisfies linter rules
