### PR TITLE
fix(ProductSync): Fix checking of an attribute difference - Issue #209

### DIFF
--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -474,7 +474,7 @@ class ProductUtils extends BaseUtils
     oldValue = oldAttribute.value
     newValue = newAttribute.value
     if _.isArray(oldValue) && _.isArray(newValue)
-      return _.difference(oldValue, newValue).length == 0
+      return _.difference(oldValue, newValue).length + _.difference(newValue, oldValue).length == 0
     else
       return false
 

--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -1277,6 +1277,9 @@ describe 'ProductUtils', ->
       delta = @utils.diff originalProduct, newProduct
       update = @utils.actionsMapAttributes delta, originalProduct, newProduct
       expect(update.length).toBe(1)
+      expect(update[0].action).toBe 'setAttribute'
+      expect(update[0].name).toBe 'test_attribute'
+      expect(update[0].value).toEqual [ 'a', 'b' ]
 
     it 'should create update action if attribute value item is added', ->
       newProduct =
@@ -1306,6 +1309,9 @@ describe 'ProductUtils', ->
       delta = @utils.diff originalProduct, newProduct
       update = @utils.actionsMapAttributes delta, originalProduct, newProduct
       expect(update.length).toBe(1)
+      expect(update[0].action).toBe 'setAttribute'
+      expect(update[0].name).toBe 'test_attribute'
+      expect(update[0].value).toEqual [ 'a', 'b', 'c' ]
 
   describe ':: actionsMapImages', ->
 

--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -1249,6 +1249,63 @@ describe 'ProductUtils', ->
       update = @utils.actionsMapAttributes delta, originalProduct, newProduct
       expect(update.length).toBe(0)
 
+    it 'should create update action if attribute value item is removed', ->
+      newProduct =
+        masterVariant:
+          sku: 'TEST MASTER VARIANT'
+          attributes: [
+            {
+              'name': 'test_attribute',
+              'value': [
+                'a', 'b'
+              ]
+            }
+          ]
+
+      originalProduct =
+        masterVariant:
+          sku: 'TEST MASTER VARIANT'
+          attributes: [
+            {
+              name: 'test_attribute',
+              value: [
+                'a', 'b', 'c'
+              ]
+            }
+          ]
+
+      delta = @utils.diff originalProduct, newProduct
+      update = @utils.actionsMapAttributes delta, originalProduct, newProduct
+      expect(update.length).toBe(1)
+
+    it 'should create update action if attribute value item is added', ->
+      newProduct =
+        masterVariant:
+          sku: 'TEST MASTER VARIANT'
+          attributes: [
+            {
+              'name': 'test_attribute',
+              'value': [
+                'a', 'b', 'c'
+              ]
+            }
+          ]
+
+      originalProduct =
+        masterVariant:
+          sku: 'TEST MASTER VARIANT'
+          attributes: [
+            {
+              name: 'test_attribute',
+              value: [
+                'a', 'b'
+              ]
+            }
+          ]
+
+      delta = @utils.diff originalProduct, newProduct
+      update = @utils.actionsMapAttributes delta, originalProduct, newProduct
+      expect(update.length).toBe(1)
 
   describe ':: actionsMapImages', ->
 


### PR DESCRIPTION
Fix #209 
- [x] commit messages are commitizen-friendly
- [x] code is unit tested
- [ ] code is integration tested
- [ ] public code is documented
- [ ] code is reviewed by at least one person
- [x] code satisfies linter rules
