### PR TITLE
fix(productSync): Update categories before categoryOrderHints

### DIFF
--- a/src/coffee/sync/product-sync.coffee
+++ b/src/coffee/sync/product-sync.coffee
@@ -47,11 +47,12 @@ class ProductSync extends BaseSync
     # sameForAll attribute value than the variants in the CTP product.
     allActions.push @_mapActionOrNot 'attributes', => @_utils.actionsMapAttributes(diff, old_obj, new_obj, @sameForAllAttributeNames)
     allActions.push variantActions.filter (action) -> action.action is 'addVariant'
-    allActions.push @_mapActionOrNot 'categories', => @_utils.actionsMapCategories(diff)
     allActions.push @_mapActionOrNot 'base', => @_utils.actionsMapBase(diff, old_obj)
     allActions.push @_mapActionOrNot 'references', => @_utils.actionsMapReferences(diff, old_obj, new_obj)
     allActions.push @_mapActionOrNot 'prices', => @_utils.actionsMapPrices(diff, old_obj, new_obj)
     allActions.push @_mapActionOrNot 'images', => @_utils.actionsMapImages(diff, old_obj, new_obj)
+    allActions.push @_mapActionOrNot 'categories', => @_utils.actionsMapCategories(diff)
+    allActions.push @_mapActionOrNot 'categoryOrderHints', => @_utils.actionsMapCategoryOrderHints(diff, old_obj)
     _.flatten allActions
 
 module.exports = ProductSync

--- a/src/coffee/sync/product-sync.coffee
+++ b/src/coffee/sync/product-sync.coffee
@@ -25,7 +25,7 @@ ProductUtils = require './utils/product'
 #     # do nothing
 class ProductSync extends BaseSync
 
-  @actionGroups = ['base', 'references', 'prices', 'attributes', 'images', 'variants', 'categories']
+  @actionGroups = ['base', 'references', 'prices', 'attributes', 'images', 'variants', 'categories', 'categoryOrderHints']
 
   # Public: Construct a `ProductSync` object.
   constructor: ->

--- a/src/coffee/sync/product-sync.coffee
+++ b/src/coffee/sync/product-sync.coffee
@@ -47,11 +47,11 @@ class ProductSync extends BaseSync
     # sameForAll attribute value than the variants in the CTP product.
     allActions.push @_mapActionOrNot 'attributes', => @_utils.actionsMapAttributes(diff, old_obj, new_obj, @sameForAllAttributeNames)
     allActions.push variantActions.filter (action) -> action.action is 'addVariant'
+    allActions.push @_mapActionOrNot 'categories', => @_utils.actionsMapCategories(diff)
     allActions.push @_mapActionOrNot 'base', => @_utils.actionsMapBase(diff, old_obj)
     allActions.push @_mapActionOrNot 'references', => @_utils.actionsMapReferences(diff, old_obj, new_obj)
     allActions.push @_mapActionOrNot 'prices', => @_utils.actionsMapPrices(diff, old_obj, new_obj)
     allActions.push @_mapActionOrNot 'images', => @_utils.actionsMapImages(diff, old_obj, new_obj)
-    allActions.push @_mapActionOrNot 'categories', => @_utils.actionsMapCategories(diff)
     _.flatten allActions
 
 module.exports = ProductSync

--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -93,27 +93,38 @@ class ProductUtils extends BaseUtils
     actions = []
     _.each actionsBaseList(), (item) =>
       action = @_buildBaseAttributesAction(item, diff, old_obj)
-      if action?.action is "setCategoryOrderHint"
-        # if the the category order hint was changed from {} to not existant
-        if action.categoryOrderHints is undefined
-          return
-        orderHintActions = Object.keys(action.categoryOrderHints)
-          .map((categoryId) ->
-            orderHint = action.categoryOrderHints[categoryId]
-            if orderHint is null or orderHint is undefined
-              orderHint = undefined
-            else
-              # stringify the order hint so that javascript numbers also get
-              # accepted as values
-              # for empty string we assume that the orderHint should be unset
-              orderHint = "#{orderHint}" || undefined
-            action: 'setCategoryOrderHint'
-            categoryId: categoryId
-            orderHint: orderHint
-          )
-        actions = actions.concat(orderHintActions)
-      else
-        actions.push action if action
+      actions.push action if action
+    actions
+
+  # Private: map categoryOrderHints actions
+  #
+  # diff - {Object} The result of diff from `jsondiffpatch`
+  # old_obj - {Object} The existing product
+  #
+  # Returns {Array} The list of actions, or empty if there are none
+  actionsMapCategoryOrderHints: (diff, old_obj) ->
+    actions = []
+    actionCategoryOrderHint = {
+      action: 'setCategoryOrderHint',
+      key: 'categoryOrderHints'
+    }
+
+    action = @_buildBaseAttributesAction(actionCategoryOrderHint, diff, old_obj)
+    if action and action.categoryOrderHints isnt undefined
+      # if the the category order hint was changed from {} to not existant
+      actions = Object.keys(action.categoryOrderHints)
+        .map (categoryId) ->
+          orderHint = action.categoryOrderHints[categoryId]
+          if orderHint is null or orderHint is undefined
+            orderHint = undefined
+          else
+            # stringify the order hint so that javascript numbers also get
+            # accepted as values
+            # for empty string we assume that the orderHint should be unset
+            orderHint = "#{orderHint}" || undefined
+          action: 'setCategoryOrderHint'
+          categoryId: categoryId
+          orderHint: orderHint
     actions
 
   # Private: map product variants
@@ -610,10 +621,6 @@ actionsBaseList = ->
     {
       action: 'changeSlug'
       key: 'slug'
-    },
-    {
-      action: 'setCategoryOrderHint',
-      key: 'categoryOrderHints'
     },
     {
       action: 'setDescription'

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -11,6 +11,8 @@ OLD_PRODUCT =
     en: 'sapphire1366126441922'
   description:
     en: 'Sample description'
+  categoryOrderHints:
+    categoryId2: 0.3
   state:
     typeId: 'state'
     id: 'old-state-id'
@@ -127,7 +129,6 @@ describe 'ProductSync', ->
         actions: [
           { action: 'changeName', name: {en: 'Foo', de: undefined, it: 'Boo'} }
           { action: 'changeSlug', slug: {en: 'foo', it: 'boo'} }
-          { action: 'setCategoryOrderHint', categoryId : 'myFancyCategoryId', orderHint : '0.9' }
           { action: 'setDescription', description: undefined }
           { action: 'setSearchKeywords', searchKeywords: en: [{text: 'new'}, {text: 'search'}, {text: 'keywords'}], "fr-BE": [{text: 'bruxelles'}, {text:'liege'}, {text: 'brugge'}] }
         ]
@@ -144,10 +145,8 @@ describe 'ProductSync', ->
           { action: 'removeVariant', id: 4 }
           { action: 'addVariant', sku: 'new', attributes: [ { name: 'what', value: 'no ID' } ] }
           { action: 'addVariant', attributes: [ { name: 'what', value: 'no SKU' } ] }
-          { action: 'addToCategory', category: 'myFancyCategoryId' }
           { action: 'changeName', name: {en: 'Foo', de: undefined, it: 'Boo'} }
           { action: 'changeSlug', slug: {en: 'foo', it: 'boo'} }
-          { action: 'setCategoryOrderHint', categoryId : 'myFancyCategoryId', orderHint : '0.9' }
           { action: 'setDescription', description: undefined }
           { action: 'setSearchKeywords', searchKeywords: en: [{text: 'new'}, {text: 'search'}, {text: 'keywords'}], "fr-BE": [{text: 'bruxelles'}, {text:'liege'}, {text: 'brugge'}]}
           { action: 'transitionState', state: { typeId: 'state', id: 'new-state-id' } }
@@ -167,6 +166,9 @@ describe 'ProductSync', ->
           { action: 'addPrice', variantId: 77, price: { value: { currencyCode: 'EUR', centAmount: 4790 }, country: 'AT', customerGroup: { id: 'special-price-id', typeId: 'customer-group' } } }
           { action: 'addPrice', variantId: 77, price: { value: { currencyCode: 'EUR', centAmount: 6559 }, country: 'FR' } }
           { action: 'addPrice', variantId: 77, price: { value: { currencyCode: 'EUR', centAmount: 13118 }, country: 'BE' } }
+          { action: 'addToCategory', category: 'myFancyCategoryId' }
+          { action: 'setCategoryOrderHint', categoryId: 'categoryId2', orderHint: undefined }
+          { action: 'setCategoryOrderHint', categoryId : 'myFancyCategoryId', orderHint : '0.9' }
         ]
         version: OLD_PRODUCT.version
       expect(update).toEqual expected_update

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -49,6 +49,9 @@ OLD_PRODUCT =
 
 NEW_PRODUCT =
   id: '123'
+  categories: [
+    'myFancyCategoryId'
+  ],
   name:
     en: 'Foo'
     it: 'Boo'
@@ -141,6 +144,7 @@ describe 'ProductSync', ->
           { action: 'removeVariant', id: 4 }
           { action: 'addVariant', sku: 'new', attributes: [ { name: 'what', value: 'no ID' } ] }
           { action: 'addVariant', attributes: [ { name: 'what', value: 'no SKU' } ] }
+          { action: 'addToCategory', category: 'myFancyCategoryId' }
           { action: 'changeName', name: {en: 'Foo', de: undefined, it: 'Boo'} }
           { action: 'changeSlug', slug: {en: 'foo', it: 'boo'} }
           { action: 'setCategoryOrderHint', categoryId : 'myFancyCategoryId', orderHint : '0.9' }

--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -765,7 +765,7 @@ describe 'ProductUtils', ->
           anotherCategoryId: '0.1'
 
       delta = @utils.diff OLD, NEW
-      update = @utils.actionsMapBase(delta, OLD)
+      update = @utils.actionsMapCategoryOrderHints(delta, OLD)
       expected_update = [
         {
           action: 'setCategoryOrderHint'
@@ -798,7 +798,7 @@ describe 'ProductUtils', ->
           categoryId: ''
 
       delta = @utils.diff OLD, NEW
-      update = @utils.actionsMapBase(delta, OLD)
+      update = @utils.actionsMapCategoryOrderHints(delta, OLD)
       expected_update = [
         {
           action: 'setCategoryOrderHint'


### PR DESCRIPTION
#### Summary
This PR fixes #218 

#### Description
When generating product update actions category actions should be placed before categoryOrderHint actions so we can add product to category and create a categoryOrderHint in one request.

#### Todo

- Tests
    - [x] Unit
    - [ ] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
