### PR TITLE
MCD-328: User can't add/change inventory quantity to 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "jsondiffpatch": "emmenko/jsondiffpatch#patch-webpack",
     "lodash.flatten": "^4.2.0",
     "lodash.foreach": "^4.2.0",
+    "lodash.isnil": "^4.0.0",
     "lodash.uniqwith": "^4.5.0",
     "loose-envify": "^1.1.0"
   },

--- a/src/sync/utils/common-actions.js
+++ b/src/sync/utils/common-actions.js
@@ -1,5 +1,6 @@
 import clone from './clone'
 import * as diffpatcher from './diffpatcher'
+import isNil from 'lodash.isnil'
 
 /**
  * Builds actions for simple object properties, given a list of actions
@@ -24,8 +25,8 @@ export function buildBaseAttributesActions ({
       const delta = diff[key]
       const before = oldObj[key]
       const now = newObj[key]
-      const hasBefore = oldObj[key] !== null && oldObj[key] !== undefined
-      const hasNow = newObj[key] !== null && newObj[key] !== undefined
+      const hasBefore = isNil(oldObj[key])
+      const hasNow = isNil(newObj[key])
 
       if (!delta) return undefined
 

--- a/src/sync/utils/common-actions.js
+++ b/src/sync/utils/common-actions.js
@@ -24,18 +24,20 @@ export function buildBaseAttributesActions ({
       const delta = diff[key]
       const before = oldObj[key]
       const now = newObj[key]
+      const hasBefore = oldObj[key] !== null && oldObj[key] !== undefined
+      const hasNow = newObj[key] !== null && newObj[key] !== undefined
 
       if (!delta) return undefined
 
-      if (!now && !before) return undefined
+      if (!hasNow && !hasBefore) return undefined
 
-      if (now && !before) // no value previously set
+      if (hasNow && !hasBefore) // no value previously set
         return { action: item.action, [actionKey]: now }
 
-      if (!now && !{}.hasOwnProperty.call(newObj, key)) // no new value
+      if (!hasNow && !{}.hasOwnProperty.call(newObj, key)) // no new value
         return undefined
 
-      if (!now && {}.hasOwnProperty.call(newObj, key)) // value unset
+      if (!hasNow && {}.hasOwnProperty.call(newObj, key)) // value unset
         return { action: item.action }
 
       // We need to clone `before` as `patch` will mutate it

--- a/test/sync/inventory-sync.spec.js
+++ b/test/sync/inventory-sync.spec.js
@@ -60,4 +60,21 @@ test('Sync::inventory', (t) => {
 
     t.end()
   })
+
+  t.test('should accept 0 as a value', (t) => {
+    setup()
+
+    const before = {
+      quantityOnStock: 1,
+    }
+    const now = {
+      quantityOnStock: 0,
+    }
+
+    const actual = inventorySync.buildActions(now, before)
+    const expected = [{ action: 'changeQuantity', quantity: 0 }]
+    t.deepEqual(actual, expected)
+
+    t.end()
+  })
 })


### PR DESCRIPTION
#### Summary
At the moment, if you try to add/change a inventory quantity with number "0" the API returns a bad request error

#### Description
This is happening because 0 is falsy, and on the buildBaseAttributesActions function it relies only on the value in order to define what to return

#### Changes made
I have added a variable to check the existence of the value (`hasNow` and `hasBefore`), so 0 wouldn't return false in this case.

#### Todo

- Tests
    - [x] Acceptance
