### PR TITLE
fix(order-sync): Fix generating delivery update actions

### DIFF
--- a/src/coffee/sync/order-sync.coffee
+++ b/src/coffee/sync/order-sync.coffee
@@ -32,7 +32,7 @@ class OrderSync extends BaseSync
     allActions = []
     allActions.push @_mapActionOrNot 'status', => @_utils.actionsMapStatusValues(diff, old_obj)
     allActions.push @_mapActionOrNot 'returnInfo', => @_utils.actionsMapReturnInfo(diff, old_obj)
-    allActions.push @_mapActionOrNot 'deliveries', => @_utils.actionsMapDeliveries(diff, new_obj)
+    allActions.push @_mapActionOrNot 'deliveries', => @_utils.actionsMapDeliveries(diff, new_obj, old_obj)
     _.flatten allActions
 
 module.exports = OrderSync

--- a/src/coffee/sync/order-sync.coffee
+++ b/src/coffee/sync/order-sync.coffee
@@ -32,7 +32,7 @@ class OrderSync extends BaseSync
     allActions = []
     allActions.push @_mapActionOrNot 'status', => @_utils.actionsMapStatusValues(diff, old_obj)
     allActions.push @_mapActionOrNot 'returnInfo', => @_utils.actionsMapReturnInfo(diff, old_obj)
-    allActions.push @_mapActionOrNot 'deliveries', => @_utils.actionsMapDeliveries(diff, old_obj)
+    allActions.push @_mapActionOrNot 'deliveries', => @_utils.actionsMapDeliveries(diff, new_obj)
     _.flatten allActions
 
 module.exports = OrderSync

--- a/src/coffee/sync/utils/order.coffee
+++ b/src/coffee/sync/utils/order.coffee
@@ -44,7 +44,7 @@ class OrderUtils extends BaseUtils
   # Returns {Array} The list of actions, or empty if there are none
   actionsMapDeliveries: (diff, new_obj, old_obj) ->
     newDeliveries = new_obj.shippingInfo?.deliveries or []
-    oldDeliveries = old_obj.shippingInfo?.deliveries or []
+    oldDeliveries = old_obj.shippingInfo.deliveries
 
     return [] unless _.has(diff, 'shippingInfo') and _.has(diff.shippingInfo, 'deliveries')
     # iterate over returnInfo instances

--- a/src/coffee/sync/utils/order.coffee
+++ b/src/coffee/sync/utils/order.coffee
@@ -62,7 +62,11 @@ class OrderUtils extends BaseUtils
         else
           # iterate over parcel instances
           _.chain deliveryDiff.parcels
-            # filter out keys starting with '_' (old removed items or _t key)
+            # keys starting with an underscore are:
+            # - _t - internal jsondiffpatch property
+            # - _N - removed keys where N is an index of a removed item
+            # We do not support removed deliveries so we filter out all
+            # keys starting with an underscore "_"
             .filter (item, key) -> key[0] isnt '_' and  _.isArray item
             .map (parcelDiff) ->
               # delivery was added

--- a/src/spec/sync/order-sync.spec.coffee
+++ b/src/spec/sync/order-sync.spec.coffee
@@ -6,6 +6,8 @@ OLD_ORDER =
   paymentState: 'Pending'
   shipmentState: 'Pending'
   version: 2
+  shippingInfo:
+    deliveries: []
 
 NEW_ORDER =
   id: '123'

--- a/src/spec/sync/order-sync.spec.coffee
+++ b/src/spec/sync/order-sync.spec.coffee
@@ -52,3 +52,115 @@ describe 'OrderSync', ->
         ]
         version: OLD_ORDER.version
       expect(update).toEqual expected_update
+
+    it 'should add new delivery and parcel', () ->
+      oldOrder =
+        shippingInfo:
+          deliveries: [{
+            id: 'old-delivery-1'
+            createdAt: '2017-05-22T07:33:02.202Z'
+            items: [
+              id: '4dc17170-30ad-4b95-9a83-1388b40f5a1e'
+              quantity: 9001
+            ]
+            parcels: [
+              id: 'parcel-123'
+              trackingData:
+                trackingId: '1111'
+                carrier: 'PPL'
+                isReturn: true
+            ]
+          }, {
+            id: 'old-delivery-2'
+            createdAt: '2017-05-22T07:33:02.202Z'
+            items: [
+              id: '4dc17170-30ad-4b95-9a83-1388b40f5a1e'
+              quantity: 9001
+            ]
+            parcels: [
+              id: 'old-parcel'
+              createdAt: '2017-05-22T07:33:02.202Z'
+              trackingData:
+                trackingId: '447883009643'
+                carrier: 'dhl'
+                isReturn: false
+            ]
+          }]
+
+      newOrder =
+        shippingInfo:
+          deliveries: [{
+            id: 'old-delivery-1'
+            createdAt: '2017-05-22T07:33:02.202Z'
+            items: [
+              id: '4dc17170-30ad-4b95-9a83-1388b40f5a1e'
+              quantity: 9001
+            ]
+            parcels: [
+              id: 'parcel-123'
+              trackingData:
+                trackingId: '1111'
+                carrier: 'PPL'
+                isReturn: true
+            ]
+          }, {
+            id: 'new-delivery'
+            items: [
+              id: '4dc17170-30ad-4b95-9a83-1388b40f5a1e'
+              quantity: 100
+            ]
+            parcels: [
+              id: 'new-delivery-parcel'
+              trackingData:
+                trackingId: '123456789'
+                carrier: 'TEST'
+                provider: 'provider 1'
+                providerTransaction: 'provider transaction 1'
+                isReturn: false
+              measurements:
+                lengthInMillimeter: 100
+                heightInMillimeter: 200
+                widthInMillimeter: 200
+                weightInGram: 500
+            ]
+          }, {
+            id: 'old-delivery-2'
+            items: [
+              id: '4dc17170-30ad-4b95-9a83-1388b40f5a1e'
+              quantity: 9001
+            ]
+            parcels: [{
+              id: 'new-parcel'
+              trackingData:
+                trackingId: '123456789'
+                carrier: 'DHL'
+                provider: 'provider'
+                providerTransaction: 'transaction provider'
+                isReturn: false
+              measurements:
+                lengthInMillimeter: 100
+                heightInMillimeter: 200
+                widthInMillimeter: 200
+                weightInGram: 500
+            }, {
+              id: 'old-parcel'
+              createdAt: '2017-05-22T07:33:02.202Z'
+              trackingData:
+                trackingId: '447883009643'
+                carrier: 'dhl'
+                isReturn: false
+            }]
+          }]
+
+      update = @sync.buildActions(newOrder, oldOrder).getUpdatePayload()
+      expect(update.actions.length).toBe 2
+
+      action = update.actions[0]
+      expect(action.action).toBe('addDelivery')
+      expect(action.id).toBe('new-delivery')
+
+      action = update.actions[1]
+      expect(action.action).toBe('addParcelToDelivery')
+      expect(action.deliveryId).toBe('old-delivery-2')
+      expect(action.id).toBe('new-parcel')
+    , 60000

--- a/src/spec/sync/utils/order.spec.coffee
+++ b/src/spec/sync/utils/order.spec.coffee
@@ -244,7 +244,7 @@ describe 'OrderUtils', ->
       delete @order.shippingInfo.deliveries
 
       delta = @utils.diff(@order, orderChanged)
-      update = @utils.actionsMapDeliveries(delta, orderChanged)
+      update = @utils.actionsMapDeliveries(delta, orderChanged, @order)
 
       action = _.deepClone(orderChanged.shippingInfo.deliveries[0])
       action.action = "addDelivery"
@@ -272,7 +272,7 @@ describe 'OrderUtils', ->
       orderChanged.shippingInfo.deliveries[0].parcels.push parcel
 
       delta = @utils.diff(@order, orderChanged)
-      update = @utils.actionsMapDeliveries(delta, orderChanged)
+      update = @utils.actionsMapDeliveries(delta, orderChanged, @order)
 
       expectedUpdate = _.deepClone parcel
       expectedUpdate.action = 'addParcelToDelivery'
@@ -291,7 +291,7 @@ describe 'OrderUtils', ->
       newOrder.shippingInfo.deliveries = [newDelivery]
 
       delta = @utils.diff(@order, newOrder)
-      update = @utils.actionsMapDeliveries(delta, newOrder)
+      update = @utils.actionsMapDeliveries(delta, newOrder, @order)
 
       action = _.deepClone(newDelivery)
       action.action = "addDelivery"
@@ -307,7 +307,7 @@ describe 'OrderUtils', ->
       newOrder.shippingInfo.deliveries[0].parcels = [newParcel]
 
       delta = @utils.diff(@order, newOrder)
-      update = @utils.actionsMapDeliveries(delta, newOrder)
+      update = @utils.actionsMapDeliveries(delta, newOrder, @order)
 
       action = _.deepClone(newParcel)
       action.action = "addParcelToDelivery"
@@ -317,7 +317,7 @@ describe 'OrderUtils', ->
     it 'should generate no update actions when there are no changes', ->
       newOrder = _.deepClone ORDER
       delta = @utils.diff(@order, newOrder)
-      update = @utils.actionsMapDeliveries(delta, newOrder)
+      update = @utils.actionsMapDeliveries(delta, newOrder, @order)
       expect(update.length).toBe 0
 
     it 'should process new deliveries and parcels in a wrong order', ->
@@ -380,7 +380,20 @@ describe 'OrderUtils', ->
               id: '4dc17170-30ad-4b95-9a83-1388b40f5a1e'
               quantity: 100
             ]
-            parcels: [
+            parcels: [{
+              id: 'new-parcel'
+              trackingData:
+                trackingId: '123456789'
+                carrier: 'DHL'
+                provider: 'provider'
+                providerTransaction: 'transaction provider'
+                isReturn: false
+              measurements:
+                lengthInMillimeter: 100
+                heightInMillimeter: 200
+                widthInMillimeter: 200
+                weightInGram: 500
+            }, {
               id: 'new-delivery-parcel'
               trackingData:
                 trackingId: '123456789'
@@ -393,7 +406,7 @@ describe 'OrderUtils', ->
                 heightInMillimeter: 200
                 widthInMillimeter: 200
                 weightInGram: 500
-            ]
+            }]
           }, {
             id: 'old-delivery-2'
             items: [
@@ -438,7 +451,7 @@ describe 'OrderUtils', ->
           }]
 
       delta = @utils.diff(oldOrder, newOrder)
-      actions = @utils.actionsMapDeliveries(delta, newOrder)
+      actions = @utils.actionsMapDeliveries(delta, newOrder, oldOrder)
 
       expect(actions.length).toBe 2
       action = actions[0]
@@ -449,3 +462,4 @@ describe 'OrderUtils', ->
       expect(action.action).toBe('addParcelToDelivery')
       expect(action.deliveryId).toBe('old-delivery-2')
       expect(action.id).toBe('new-parcel')
+

--- a/src/spec/sync/utils/order.spec.coffee
+++ b/src/spec/sync/utils/order.spec.coffee
@@ -241,7 +241,7 @@ describe 'OrderUtils', ->
       orderChanged = _.deepClone ORDER
 
       # empty deliveries list
-      delete @order.shippingInfo.deliveries
+      @order.shippingInfo.deliveries = []
 
       delta = @utils.diff(@order, orderChanged)
       update = @utils.actionsMapDeliveries(delta, orderChanged, @order)

--- a/src/spec/sync/utils/order.spec.coffee
+++ b/src/spec/sync/utils/order.spec.coffee
@@ -380,33 +380,6 @@ describe 'OrderUtils', ->
               id: '4dc17170-30ad-4b95-9a83-1388b40f5a1e'
               quantity: 100
             ]
-            parcels: [{
-              id: 'new-parcel'
-              trackingData:
-                trackingId: '123456789'
-                carrier: 'DHL'
-                provider: 'provider'
-                providerTransaction: 'transaction provider'
-                isReturn: false
-              measurements:
-                lengthInMillimeter: 100
-                heightInMillimeter: 200
-                widthInMillimeter: 200
-                weightInGram: 500
-            }, {
-              id: 'new-delivery-parcel'
-              trackingData:
-                trackingId: '123456789'
-                carrier: 'TEST'
-                provider: 'provider 1'
-                providerTransaction: 'provider transaction 1'
-                isReturn: false
-              measurements:
-                lengthInMillimeter: 100
-                heightInMillimeter: 200
-                widthInMillimeter: 200
-                weightInGram: 500
-            }]
           }, {
             id: 'old-delivery-2'
             items: [

--- a/src/spec/sync/utils/order.spec.coffee
+++ b/src/spec/sync/utils/order.spec.coffee
@@ -237,12 +237,11 @@ describe 'OrderUtils', ->
 
   describe ':: actionsMapDeliveries', ->
 
-    it 'should return required actions for syncing deliveries', ->
-
+    it 'should return addDelivery action when syncing deliveries', ->
       orderChanged = _.deepClone ORDER
 
       # empty deliveries list
-      @order.shippingInfo.deliveries = []
+      delete @order.shippingInfo.deliveries
 
       delta = @utils.diff(@order, orderChanged)
       update = @utils.actionsMapDeliveries(delta, orderChanged)
@@ -252,8 +251,7 @@ describe 'OrderUtils', ->
 
       expect(update).toEqual [action]
 
-    it 'should return required action for syncing parcels (deliveries)', ->
-
+    it 'should return addParcelToDelivery action when syncing parcels (deliveries)', ->
       orderChanged = _.deepClone ORDER
 
       parcel =
@@ -281,3 +279,173 @@ describe 'OrderUtils', ->
       expectedUpdate.deliveryId = orderChanged.shippingInfo.deliveries[0].id
 
       expect(update).toEqual [expectedUpdate]
+
+    it 'should add delivery when old deliveries are not provided', ->
+      newOrder = _.deepClone ORDER
+      newDelivery =
+        id: uniqueId 'new'
+        items: [
+          lineItemId: 2
+          quantity: 10
+        ]
+      newOrder.shippingInfo.deliveries = [newDelivery]
+
+      delta = @utils.diff(@order, newOrder)
+      update = @utils.actionsMapDeliveries(delta, newOrder)
+
+      action = _.deepClone(newDelivery)
+      action.action = "addDelivery"
+
+      expect(update).toEqual [action]
+
+    it 'should add parcel when old parcels are not provided', ->
+      newOrder = _.deepClone ORDER
+      newParcel =
+        id: uniqueId 'newParcel'
+        trackingData:
+          trackingId: uniqueId 'newTrackingId'
+      newOrder.shippingInfo.deliveries[0].parcels = [newParcel]
+
+      delta = @utils.diff(@order, newOrder)
+      update = @utils.actionsMapDeliveries(delta, newOrder)
+
+      action = _.deepClone(newParcel)
+      action.action = "addParcelToDelivery"
+      action.deliveryId = newOrder.shippingInfo.deliveries[0].id
+      expect(update).toEqual [action]
+
+    it 'should generate no update actions when there are no changes', ->
+      newOrder = _.deepClone ORDER
+      delta = @utils.diff(@order, newOrder)
+      update = @utils.actionsMapDeliveries(delta, newOrder)
+      expect(update.length).toBe 0
+
+    it 'should process new deliveries and parcels in a wrong order', ->
+      oldOrder =
+        shippingInfo:
+          deliveries: [{
+            id: 'old-delivery-1'
+            createdAt: '2017-05-22T07:33:02.202Z'
+            items: [
+              id: '4dc17170-30ad-4b95-9a83-1388b40f5a1e'
+              quantity: 100
+            ]
+            parcels: [
+              id: 'parcel-123'
+              trackingData:
+                trackingId: '1111'
+                carrier: 'PPL'
+                isReturn: true
+            ]
+          }, {
+            id: 'old-delivery-2'
+            createdAt: '2017-05-22T07:33:02.202Z'
+            items: [
+              id: '4dc17170-30ad-4b95-9a83-1388b40f5a1e'
+              quantity: 200
+            ]
+            parcels: [
+              id: 'old-parcel'
+              createdAt: '2017-05-22T07:33:02.202Z'
+              trackingData:
+                trackingId: '447883009643'
+                carrier: 'dhl'
+                isReturn: false
+            ]
+          }, {
+            id: 'old-delivery-3'
+            items: [
+              id: '4dc17170-30ad-4b95-9a83-1388b40f5a1e'
+              quantity: 300
+            ]
+            parcels: [
+              id: 'parcel-300'
+            ]
+          }]
+
+      newOrder =
+        shippingInfo:
+          deliveries: [{
+            id: 'old-delivery-3'
+            items: [
+              id: '4dc17170-30ad-4b95-9a83-1388b40f5a1e'
+              quantity: 300
+            ]
+            parcels: [
+              id: 'parcel-300'
+            ]
+          }, {
+            id: 'new-delivery'
+            items: [
+              id: '4dc17170-30ad-4b95-9a83-1388b40f5a1e'
+              quantity: 100
+            ]
+            parcels: [
+              id: 'new-delivery-parcel'
+              trackingData:
+                trackingId: '123456789'
+                carrier: 'TEST'
+                provider: 'provider 1'
+                providerTransaction: 'provider transaction 1'
+                isReturn: false
+              measurements:
+                lengthInMillimeter: 100
+                heightInMillimeter: 200
+                widthInMillimeter: 200
+                weightInGram: 500
+            ]
+          }, {
+            id: 'old-delivery-2'
+            items: [
+              id: '4dc17170-30ad-4b95-9a83-1388b40f5a1e'
+              quantity: 9001
+            ]
+            parcels: [{
+              id: 'new-parcel'
+              trackingData:
+                trackingId: '123456789'
+                carrier: 'DHL'
+                provider: 'provider'
+                providerTransaction: 'transaction provider'
+                isReturn: false
+              measurements:
+                lengthInMillimeter: 100
+                heightInMillimeter: 200
+                widthInMillimeter: 200
+                weightInGram: 500
+            }, {
+              id: 'old-parcel'
+              createdAt: '2017-05-22T07:33:02.202Z'
+              trackingData:
+                trackingId: '447883009643'
+                carrier: 'dhl'
+                isReturn: false
+            }]
+          }, {
+            id: 'old-delivery-1'
+            createdAt: '2017-05-22T07:33:02.202Z'
+            items: [
+              id: '4dc17170-30ad-4b95-9a83-1388b40f5a1e'
+              quantity: 9001
+            ]
+            parcels: [
+              id: 'parcel-123'
+              trackingData:
+                trackingId: '1111'
+                carrier: 'PPL'
+                isReturn: true
+            ]
+          }]
+
+      delta = @utils.diff(oldOrder, newOrder)
+      actions = @utils.actionsMapDeliveries(delta, newOrder)
+
+      expect(actions.length).toBe 2
+      action = actions[0]
+      expect(action.action).toBe('addDelivery')
+      expect(action.id).toBe('new-delivery')
+
+      action = actions[1]
+      expect(action.action).toBe('addParcelToDelivery')
+      expect(action.deliveryId).toBe('old-delivery-2')
+      expect(action.id).toBe('new-parcel')

--- a/src/spec/utils.spec.coffee
+++ b/src/spec/utils.spec.coffee
@@ -48,6 +48,7 @@ describe 'Utils', ->
       {amount: 10, type: 'h', expected_time: 10 * 1000 * 60 * 60}
       {amount: 15, type: 'd', expected_time: 15 * 1000 * 60 * 60 * 24}
       {amount: 12, type: 'w', expected_time: 12 * 1000 * 60 * 60 * 24 * 7}
+      {amount: 12, type: 'unknown', expected_time: 0}
     ], (o) ->
       it "should get time in milliseconds for '#{o.type}'", ->
         expect(Utils.getTime(o.amount, o.type)).toBe o.expected_time


### PR DESCRIPTION
#### Summary
Fixes #229 
When adding a new parcel to a delivery, the script goes through all deliveries to find proper `deliveryId`. It also ignores all diffs items starting with an underscore `_` because those items were removed and we do not currently support removed deliveries/parcels.

This PR also improves code coverage:
- [x] should generate correct update actions when a new delivery is added to the new object
- [x] should be agnostic of the index(position) of the deliveries in both new and old order object
- [x] should generate correction update actions a new parcel has been added
- [x] should work when no deliveries was existing in old order
- [x] should work when only new deliveries are provided without providing existing deliveries in the old order object (this is possible for orders because it's *currently* not possible to remove deliveries from an order)
- [ ] should throw if there is no deliveryId in the new order object (check if consistent with similar implementations in other entities)
> Here I discovered that the `deliveryId` has to be always present when adding new parcel because if it is missing, the script will add whole delivery instead of just a parcel.
- [x] should be idempotent, passing the same object should return empty actions
