### PR TITLE
feat(productSync): Support key and variant key sync action

### DIFF
--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -379,6 +379,7 @@ class ProductUtils extends BaseUtils
             updated[k] = diffed_value
 
       # extend with an old object only if value is an object or an array
+      # if the new value is not an array or an object, use just the new value
       if old_obj[key] and (_.isArray(old_obj[key]) or _.isObject(old_obj[key]))
         # extend values of original object with possible new values of the diffed object
         # e.g.:

--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -294,6 +294,9 @@ class ProductUtils extends BaseUtils
     if masterVariant
       skuAction = @_buildSkuActions(masterVariant, old_obj.masterVariant)
       actions.push(skuAction) if skuAction?
+      # variant key update action
+      keyAction = @_buildVariantKeyActions(masterVariant, old_obj.masterVariant)
+      actions.push(keyAction) if keyAction?
       attributes = masterVariant.attributes
       attrActions = @_buildVariantAttributesActions attributes, old_obj.masterVariant, new_obj.masterVariant, sameForAllAttributeNames
       actions = actions.concat attrActions
@@ -306,6 +309,9 @@ class ProductUtils extends BaseUtils
             index_new = variant._NEW_ARRAY_INDEX[0]
             skuAction = @_buildSkuActions(variant, old_obj.variants[index_old])
             actions.push(skuAction) if skuAction?
+            # variant key update action
+            keyAction = @_buildVariantKeyActions(variant, old_obj.variants[index_old])
+            actions.push(keyAction) if keyAction?
             attributes = variant.attributes
             attrActions = @_buildVariantAttributesActions attributes, old_obj.variants[index_old], new_obj.variants[index_new], sameForAllAttributeNames
             actions = actions.concat attrActions
@@ -372,7 +378,8 @@ class ProductUtils extends BaseUtils
             # no idea what this is but lets just use it for updating
             updated[k] = diffed_value
 
-      if old_obj[key]
+      # extend with an old object only if value is an object or an array
+      if old_obj[key] and (_.isArray(old_obj[key]) or _.isObject(old_obj[key]))
         # extend values of original object with possible new values of the diffed object
         # e.g.:
         #   old = {en: 'foo'}
@@ -384,6 +391,7 @@ class ProductUtils extends BaseUtils
         old = updated
       action =
         action: item.action
+      # what if updated value is null, empty string or zero?
       if updated
         action[key] = old
       else
@@ -606,6 +614,13 @@ class ProductUtils extends BaseUtils
         variantId: old_variant.id
         sku: @getDeltaValue(variantDiff.sku)
 
+  _buildVariantKeyActions: (variantDiff, old_variant) ->
+    if _.has variantDiff, 'key'
+      action =
+        action: 'setProductVariantKey'
+        sku: old_variant.sku
+        key: @getDeltaValue(variantDiff.key)
+
 module.exports = ProductUtils
 
 #################
@@ -614,6 +629,10 @@ module.exports = ProductUtils
 
 actionsBaseList = ->
   [
+    {
+      action: 'setKey'
+      key: 'key'
+    },
     {
       action: 'changeName'
       key: 'name'

--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -647,6 +647,7 @@ describe 'ProductUtils', ->
 
     it 'should diff if basic attribute is undefined', ->
       OLD =
+        key: 'oldKey'
         id: '123'
         name:
           en: 'Foo'
@@ -655,6 +656,7 @@ describe 'ProductUtils', ->
         masterVariant:
           id: 1
       NEW =
+        key: 'newKey'
         id: '123'
         name:
           de: 'Boo'
@@ -671,6 +673,7 @@ describe 'ProductUtils', ->
       delta = @utils.diff OLD, NEW
       update = @utils.actionsMapBase(delta, OLD)
       expected_update = [
+        { action: 'setKey', key: 'newKey' }
         { action: 'changeName', name: {en: undefined, de: 'Boo'} }
         { action: 'changeSlug', slug: {en: 'boo'} }
         { action: 'setDescription', description: {en: 'Sample', it: 'Esempio'} }
@@ -890,6 +893,56 @@ describe 'ProductUtils', ->
       update = @utils.actionsMapAttributes delta, OLD_VARIANT, NEW_VARIANT
       expected_update = [
         { action: 'setAttribute', variantId: 3, name: 'foo', value: 'CHANGED' }
+      ]
+      expect(update).toEqual expected_update
+
+    it 'should create actions for changed variant keys', ->
+      OLD =
+        id: '123'
+        masterVariant:
+          sku: 'masterSku'
+          key: 'oldKey'
+        variants: [
+          {
+            sku: 'variantSku'
+            key: 'oldVariantKey'
+          },
+          {
+            sku: 'variantSku2'
+            key: 'oldVariantKey2'
+          },
+          {
+            sku: 'variantSku3'
+          }
+        ]
+
+      NEW =
+        id: '123'
+        masterVariant:
+          sku: 'masterSku'
+          key: 'newKey'
+        variants: [
+          {
+            sku: 'variantSku'
+            key: 'newVariantKey'
+          },
+          {
+            sku: 'variantSku2'
+          },
+          {
+            sku: 'variantSku3'
+            key: 'newVariantKey3'
+          }
+        ]
+
+      delta = @utils.diff OLD, NEW
+      update = @utils.actionsMapAttributes delta, OLD, NEW
+
+      expected_update = [
+        { action: 'setProductVariantKey', sku: 'masterSku', key: 'newKey' }
+        { action: 'setProductVariantKey', sku: 'variantSku', key: 'newVariantKey' }
+        { action: 'setProductVariantKey', sku: 'variantSku2', key: undefined }
+        { action: 'setProductVariantKey', sku: 'variantSku3', key: 'newVariantKey3' }
       ]
       expect(update).toEqual expected_update
 
@@ -1151,7 +1204,6 @@ describe 'ProductUtils', ->
         ]
       expect(update).toEqual expected_update
 
-
     it 'should not modify original attributes', ->
       newProduct =
         masterVariant:
@@ -1350,7 +1402,6 @@ describe 'ProductUtils', ->
       _.each(expected_update, (expectedAction) ->
         expect(update).toContain expectedAction
       )
-
 
     it 'should not build actions if images are not set', ->
       oldProduct =


### PR DESCRIPTION
#### Summary
Resolves #236 - This PR adds a support for product.key and variant.key sync action.

#### Description
<!-- Describe the changes in this PR here and provide some context -->

#### Todo

- Tests
    - [x] Unit
    - [ ] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
