### PR TITLE
fix(productSync): Fix product sync update key and variantKey action

### DIFF
--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -619,7 +619,7 @@ class ProductUtils extends BaseUtils
     if _.has variantDiff, 'key'
       action =
         action: 'setProductVariantKey'
-        sku: old_variant.sku
+        variantId: old_variant.id
         key: @getDeltaValue(variantDiff.key)
 
 module.exports = ProductUtils

--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -900,18 +900,22 @@ describe 'ProductUtils', ->
       OLD =
         id: '123'
         masterVariant:
+          id: 1
           sku: 'masterSku'
           key: 'oldKey'
         variants: [
           {
+            id: 2
             sku: 'variantSku'
             key: 'oldVariantKey'
           },
           {
+            id: 3
             sku: 'variantSku2'
             key: 'oldVariantKey2'
           },
           {
+            id: 4
             sku: 'variantSku3'
           }
         ]
@@ -939,10 +943,10 @@ describe 'ProductUtils', ->
       update = @utils.actionsMapAttributes delta, OLD, NEW
 
       expected_update = [
-        { action: 'setProductVariantKey', sku: 'masterSku', key: 'newKey' }
-        { action: 'setProductVariantKey', sku: 'variantSku', key: 'newVariantKey' }
-        { action: 'setProductVariantKey', sku: 'variantSku2', key: undefined }
-        { action: 'setProductVariantKey', sku: 'variantSku3', key: 'newVariantKey3' }
+        { action: 'setProductVariantKey', variantId: 1, key: 'newKey' }
+        { action: 'setProductVariantKey', variantId: 2, key: 'newVariantKey' }
+        { action: 'setProductVariantKey', variantId: 3, key: undefined }
+        { action: 'setProductVariantKey', variantId: 4, key: 'newVariantKey3' }
       ]
       expect(update).toEqual expected_update
 


### PR DESCRIPTION
#### Summary
Update actions are done using `variantId` instead of `sku`.


#### Todo
- Tests
    - [x] Unit
