### PR TITLE
Export repeaterTaskQueue from sdk

### DIFF
--- a/src/coffee/main.coffee
+++ b/src/coffee/main.coffee
@@ -7,4 +7,5 @@ module.exports =
   InventorySync: require './sync/inventory-sync'
   CategorySync: require './sync/category-sync'
   TaskQueue: require './task-queue'
+  RepeaterTaskQueue: require './repeater-task-queue'
   Errors: require './errors'


### PR DESCRIPTION
#### Summary
This PR exports `RepeaterTaskQueue` from SDK so it can be customized and used later for repeating API calls in the client.

Resolves https://github.com/sphereio/sphere-node-sdk/issues/247


