### PR TITLE
fix(repeater): Allow default configuration

### DIFF
--- a/src/coffee/repeater-task-queue.coffee
+++ b/src/coffee/repeater-task-queue.coffee
@@ -38,7 +38,7 @@ retryKeywords = [
 class RepeaterTaskQueue extends TaskQueue
 
 
-  constructor: (options, repeaterOptions) ->
+  constructor: (options = {}, repeaterOptions = {}) ->
     super options
     repeaterOptions = _.defaults repeaterOptions,
       attempts: 50


### PR DESCRIPTION
#### Summary
When [repeaterOptions](https://github.com/sphereio/sphere-node-sdk/blob/247-allow-undefined-configuration/src/coffee/repeater-task-queue.coffee#L41) is not specified:
```js
console.log(_.defaults(undefined, {a: 1})) // -> undefined
```
Which results in error:
```
Cannot read property 'retryKeywords' of undefined
```
