### PR TITLE
fix(rest): set correct predicate in paged iteration

### DIFF
--- a/src/coffee/connect/rest.coffee
+++ b/src/coffee/connect/rest.coffee
@@ -209,7 +209,7 @@ class Rest
       wherePredicate = if params.where then {where: params.where} else {}
       if lastId
         lastIdPredicate = encodeURIComponent("id > \"#{lastId}\"")
-        wherePredicate = {where: if params.where then "#{params.where}%20and%20#{lastIdPredicate}" else lastIdPredicate}
+        wherePredicate = {where: if params.where then "(#{params.where})%20and%20#{lastIdPredicate}" else lastIdPredicate}
       debug 'PAGED where predicate: %j', wherePredicate
 
       queryParams = _.stringifyQuery(_.extend({}, params,


### PR DESCRIPTION
#### Summary
PR sets correct predicate string inside the paged function.

#### Description
More reading and details on this issue can be found here: https://github.com/sphereio/sphere-node-sdk/issues/267

resolves #267