### PR TITLE
feat(category-sync): Add a possibility to sync category custom fields

### DIFF
--- a/src/coffee/sync/category-sync.coffee
+++ b/src/coffee/sync/category-sync.coffee
@@ -26,7 +26,10 @@ class CategorySync extends BaseSync
     @_utils = new CategoryUtil()
 
   _doMapActions: (diff, new_obj, old_obj) ->
-    actions = @_utils.actionsMap diff, new_obj
+    actions = []
+    actions.push @_utils.actionsMap diff, new_obj
+    actions.push @_utils.actionsMapCustomFields new_obj, old_obj
+    _.flatten actions
 
   _doUpdate: ->
     @_client.categories.byId(@_data.updateId).update(@_data.update)

--- a/src/coffee/sync/utils/category.coffee
+++ b/src/coffee/sync/utils/category.coffee
@@ -29,6 +29,51 @@ class CategoryUtils extends BaseUtils
 
     actions
 
+  # Private: map actions for managing custom fields
+  #
+  # new_obj - {Object} The new category draft
+  # old_obj - {Object} The old category object
+  #
+  # Returns {Array} The list of actions, or empty if there are none
+  actionsMapCustomFields: (new_obj, old_obj) ->
+    actions = []
+    newCustom = new_obj.custom
+    oldCustom = old_obj.custom
+
+    if newCustom and oldCustom and @referencesAreEqual(newCustom.type, oldCustom.type)
+      # compare single fields one by one
+
+      # handle new and changed fields
+      _.mapObject(newCustom.fields, (val, name) =>
+        if not _.isEqual val, oldCustom.fields[name]
+          action =
+            action: 'setCustomField'
+            name: name
+
+          if val
+            action.value = JSON.parse(JSON.stringify(val))
+
+          actions.push action
+      )
+
+      # handle removed fields
+      _.mapObject(oldCustom.fields, (val, name) =>
+        if not newCustom.fields[name]
+          actions.push
+            action: 'setCustomField'
+            name: name
+      )
+
+    else if newCustom or oldCustom # or both but different customTypes
+      action = if newCustom then JSON.parse(JSON.stringify(newCustom)) else {}
+      action.action = 'setCustomType'
+      actions.push action
+
+    actions
+
+  referencesAreEqual: (refA, refB) ->
+    (refA.id and refA.id == refB.id) or (refA.key and refA.key == refB.key)
+
 module.exports = CategoryUtils
 
 #################

--- a/src/spec/sync/category-sync.spec.coffee
+++ b/src/spec/sync/category-sync.spec.coffee
@@ -96,3 +96,181 @@ describe 'CategorySync', ->
 
       update = @sync.buildActions(newCategory, category).getUpdatePayload()
       expect(update).toBeUndefined()
+
+    it 'should add custom fields object using setCustomType update action', ->
+      category =
+        id: 'c123'
+        key: 'key123'
+        # no custom property
+
+      newCategory =
+        id: 'c123'
+        key: 'key123'
+        custom:
+          type:
+            typeId: 'type'
+            id: 'customTypeId'
+          fields:
+            customFieldName: 'value'
+
+      update = @sync.buildActions(newCategory, category).getUpdatePayload()
+      expect(update).toBeDefined()
+
+      expect(_.size update.actions).toBe 1
+      expect(update.actions[0]).toEqual
+        action: 'setCustomType'
+        type:
+          typeId: 'type'
+          id: 'customTypeId'
+        fields:
+          customFieldName: 'value'
+
+    it 'should change whole custom object when new customType is provided', ->
+      category =
+        id: 'c123'
+        key: 'key123'
+        custom:
+          type:
+            typeId: 'type'
+            id: 'customTypeId'
+          fields:
+            customFieldName: 'value'
+
+      newCategory =
+        id: 'c123'
+        key: 'key123'
+        custom:
+          type:
+            typeId: 'type'
+            id: 'customTypeIdChanged'
+          fields:
+            differentCustomKey: 'value2'
+
+      update = @sync.buildActions(newCategory, category).getUpdatePayload()
+      expect(update).toBeDefined()
+
+      expect(_.size update.actions).toBe 1
+      expect(update.actions[0]).toEqual
+        action: 'setCustomType'
+        type:
+          typeId: 'type'
+          id: 'customTypeIdChanged'
+        fields:
+          differentCustomKey: 'value2'
+
+    it 'should remove custom fields using setCustomType update action', ->
+      category =
+        id: 'c123'
+        key: 'key123'
+        custom:
+          type:
+            typeId: 'type'
+            id: 'customTypeId'
+          fields:
+            customFieldName: 'value'
+
+      newCategory =
+        id: 'c123'
+        key: 'key123'
+        # removed custom fields
+
+      update = @sync.buildActions(newCategory, category).getUpdatePayload()
+      expect(update).toBeDefined()
+
+      expect(_.size update.actions).toBe 1
+      expect(update.actions[0]).toEqual
+        action: 'setCustomType'
+        # will remove custom fields
+
+    it 'should add a new custom field using setCustomField update action', ->
+      category =
+        id: 'c123'
+        key: 'key123'
+        custom:
+          type:
+            typeId: 'type'
+            id: 'customTypeId'
+          fields:
+            persistedField: 123
+
+      newCategory =
+        id: 'c123'
+        key: 'key123'
+        custom:
+          type:
+            typeId: 'type'
+            id: 'customTypeId'
+          fields:
+            persistedField: 123
+            newField: 'newValue'
+
+
+      update = @sync.buildActions(newCategory, category).getUpdatePayload()
+      expect(update).toBeDefined()
+
+      expect(_.size update.actions).toBe 1
+      expect(update.actions[0]).toEqual
+        action: 'setCustomField'
+        name: 'newField'
+        value: 'newValue'
+
+    it 'should change custom field using setCustomField update action', ->
+      category =
+        id: 'c123'
+        key: 'key123'
+        custom:
+          type:
+            typeId: 'type'
+            id: 'customTypeId'
+          fields:
+            customFieldName: 'value'
+
+      newCategory =
+        id: 'c123'
+        key: 'key123'
+        custom:
+          type:
+            typeId: 'type'
+            id: 'customTypeId'
+          fields:
+            customFieldName: 'changedValue'
+
+      update = @sync.buildActions(newCategory, category).getUpdatePayload()
+      expect(update).toBeDefined()
+
+      expect(_.size update.actions).toBe 1
+      expect(update.actions[0]).toEqual
+        action: 'setCustomField'
+        name: 'customFieldName'
+        value: 'changedValue'
+
+    it 'should remove custom field using setCustomField update action', ->
+      category =
+        id: 'c123'
+        key: 'key123'
+        custom:
+          type:
+            typeId: 'type'
+            id: 'customTypeId'
+          fields:
+            persistedField: 123
+            customFieldName: 'value'
+
+      newCategory =
+        id: 'c123'
+        key: 'key123'
+        custom:
+          type:
+            typeId: 'type'
+            id: 'customTypeId'
+          fields:
+            persistedField: 123
+
+      update = @sync.buildActions(newCategory, category).getUpdatePayload()
+      expect(update).toBeDefined()
+
+      expect(_.size update.actions).toBe 1
+      expect(update.actions[0]).toEqual
+        action: 'setCustomField'
+        name: 'customFieldName'
+        # will remove


### PR DESCRIPTION
This PR adds a possibility to sync category custom fields.
Resolves #280

#### Todo

- Tests
    - [x] Unit
    - [ ] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
