### PR TITLE
fix(categorySync): Sync properly boolean values in category sync

### DIFF
--- a/src/coffee/sync/utils/category.coffee
+++ b/src/coffee/sync/utils/category.coffee
@@ -50,7 +50,7 @@ class CategoryUtils extends BaseUtils
             action: 'setCustomField'
             name: name
 
-          if val
+          if not _.isUndefined(val)
             action.value = JSON.parse(JSON.stringify(val))
 
           actions.push action
@@ -58,7 +58,7 @@ class CategoryUtils extends BaseUtils
 
       # handle removed fields
       _.mapObject(oldCustom.fields, (val, name) =>
-        if not newCustom.fields[name]
+        if _.isUndefined(newCustom.fields[name])
           actions.push
             action: 'setCustomField'
             name: name

--- a/src/spec/sync/category-sync.spec.coffee
+++ b/src/spec/sync/category-sync.spec.coffee
@@ -224,6 +224,7 @@ describe 'CategorySync', ->
             id: 'customTypeId'
           fields:
             customFieldName: 'value'
+            booleanAttribute: true
 
       newCategory =
         id: 'c123'
@@ -234,15 +235,26 @@ describe 'CategorySync', ->
             id: 'customTypeId'
           fields:
             customFieldName: 'changedValue'
+            booleanAttribute: false
 
       update = @sync.buildActions(newCategory, category).getUpdatePayload()
       expect(update).toBeDefined()
 
-      expect(_.size update.actions).toBe 1
-      expect(update.actions[0]).toEqual
+      expect(_.size update.actions).toBe 2
+
+      actionsByName = _.indexBy(update.actions, 'name')
+
+      expect(actionsByName.customFieldName).toBeDefined()
+      expect(actionsByName.customFieldName).toEqual
         action: 'setCustomField'
         name: 'customFieldName'
         value: 'changedValue'
+
+      expect(actionsByName.booleanAttribute).toBeDefined()
+      expect(actionsByName.booleanAttribute).toEqual
+        action: 'setCustomField'
+        name: 'booleanAttribute'
+        value: false
 
     it 'should remove custom field using setCustomField update action', ->
       category =


### PR DESCRIPTION
#### Summary
This PR fixes how we sync boolean attributes.
Before this PR it generated remove action when I was changing `true` value to `false`.

**Lesson learned:** be more specific when dealing with `falsy` values.

#### Todo

- Tests
    - [x] Unit
    - [ ] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
