### PR TITLE
fix(getVersion): add Utils to public interface of this module

### DIFF
--- a/src/coffee/main.coffee
+++ b/src/coffee/main.coffee
@@ -9,3 +9,4 @@ module.exports =
   TaskQueue: require './task-queue'
   RepeaterTaskQueue: require './repeater-task-queue'
   Errors: require './errors'
+  Utils: require './utils'


### PR DESCRIPTION
#### Summary
need Utils in the public interface to use it from sphere-node-utils

#### Description
Utils is exported, now it can be used externally. Because the new getVersion method is thought to be used externally. This is required to fix a vulnerability in sphere-node-utils that is spreading throughout the tools code base

#### Todo

- Tests
    - [x ] Unit
    - [ x] Integration
    - [x ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
