### PR TITLE
feat(product-sync): on product variant actions, use SKU as the first option instead of variantId.

### DIFF
--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -426,7 +426,7 @@ class ProductUtils extends BaseUtils
           else if _.has(image, 'label') and
           (image.label.length == 1 or image.label.length == 2)
             action =
-              action: 'changeImageLabel'
+              action: 'setImageLabel'
               imageUrl: old_variant.images[key].url
               label: new_variant.images[key].label
             @_setSkuOrVariantIdToUpdateAction(old_variant, action)

--- a/src/coffee/sync/utils/product.coffee
+++ b/src/coffee/sync/utils/product.coffee
@@ -439,21 +439,21 @@ class ProductUtils extends BaseUtils
           actions.push action if action
     actions
 
-  _buildAddExternalImageAction: (variant, image) ->
+  _buildAddExternalImageAction: (old_variant, image) ->
     if image
       delete image._MATCH_CRITERIA
       action =
         action: 'addExternalImage'
         image: image
-      @_setSkuOrVariantIdToUpdateAction(variant, action)
+      @_setSkuOrVariantIdToUpdateAction(old_variant, action)
     action
 
-  _buildRemoveImageAction: (variant, image) ->
+  _buildRemoveImageAction: (old_variant, image) ->
     if image
       action =
         action: 'removeImage'
         imageUrl: image.url
-      @_setSkuOrVariantIdToUpdateAction(variant, action)
+      @_setSkuOrVariantIdToUpdateAction(old_variant, action)
     action
 
   _isExistingAttribute: (oldAttribute, newAttribute) ->
@@ -520,7 +520,7 @@ class ProductUtils extends BaseUtils
               action.value = text
     action
 
-  _buildNewSetAttributeAction: (oldVariant, el, sameForAllAttributeNames) ->
+  _buildNewSetAttributeAction: (old_variant, el, sameForAllAttributeNames) ->
     attributeName = el?.name
     return unless attributeName
     action =
@@ -528,7 +528,7 @@ class ProductUtils extends BaseUtils
       name: attributeName
       value: el.value
 
-    @_setSkuOrVariantIdToUpdateAction(oldVariant, action)
+    @_setSkuOrVariantIdToUpdateAction(old_variant, action)
 
     if _.isArray(action.value)
       _.each action.value, (v) ->

--- a/src/spec/client/services/base.spec.coffee
+++ b/src/spec/client/services/base.spec.coffee
@@ -149,7 +149,7 @@ describe 'Service', ->
       _.each ['30s', '15m', '12h', '7d', '2w'], (type) ->
         it "should allow to query for last #{type}", ->
           @service.last(type)
-          expect(@service._params.query.where[0]).toMatch /lastModifiedAt%20%3E%20%22201\d-\d\d-\d\dT\d\d%3A\d\d%3A\d\d.\d\d\dZ%22/
+          expect(@service._params.query.where[0]).toMatch /lastModifiedAt%20%3E%20%2220\d\d-\d\d-\d\dT\d\d%3A\d\d%3A\d\d.\d\d\dZ%22/
 
       it 'should throw an exception when the period for last can not be parsed', ->
         expect(=> @service.last('30')).toThrow new Error "Cannot parse period '30'"

--- a/src/spec/sync/product-sync-sku-match.spec.coffee
+++ b/src/spec/sync/product-sync-sku-match.spec.coffee
@@ -71,7 +71,7 @@ describe 'ProductUtils SKU based matching', ->
       { action: 'addVariant', sku: 'vN', attributes: [{name: 'attribN', value: 'valN'}] }
     ]
     compareAttributeActions @sync, @oldProduct, @newProduct, [
-      { action: 'setAttribute', variantId: 9, name: 'attrib', value: 'CHANGED' }
+      { action: 'setAttribute', sku: 'v2', name: 'attrib', value: 'CHANGED' }
     ]
 
   it 'should work when the order of variant has changed', ->
@@ -91,8 +91,8 @@ describe 'ProductUtils SKU based matching', ->
     compareVariantActions @sync, @oldProduct, @newProduct,  []
 
     compareAttributeActions @sync, @oldProduct, @newProduct, [
-      { action: 'setAttribute', variantId: 5, name: 'attrib5', value: 'CHANGED5' }
-      { action: 'setAttribute', variantId: 2, name: 'attrib2', value: 'CHANGED2' }
+      { action: 'setAttribute', sku: 'v5', name: 'attrib5', value: 'CHANGED5' }
+      { action: 'setAttribute', sku: 'v2', name: 'attrib2', value: 'CHANGED2' }
     ]
 
   it 'should work in combination with variant additions and removes', ->
@@ -115,8 +115,8 @@ describe 'ProductUtils SKU based matching', ->
     ]
 
     compareAttributeActions @sync, @oldProduct, @newProduct, [
-      { action: 'setAttribute', variantId: 3, name: 'attrib3', value: 'CHANGED3' }
-      { action: 'setAttribute', variantId: 5, name: 'attrib5', value: 'CHANGED5' }
+      { action: 'setAttribute', sku: 'v3', name: 'attrib3', value: 'CHANGED3' }
+      { action: 'setAttribute', sku: 'v5', name: 'attrib5', value: 'CHANGED5' }
     ]
 
   it 'should work when master variant was switched with another variant', ->
@@ -135,6 +135,6 @@ describe 'ProductUtils SKU based matching', ->
       { action : 'changeMasterVariant', sku : 'v3' }
     ]
     compareAttributeActions @sync, @oldProduct, @newProduct, [
-      { action: 'setAttribute', variantId: 3, name: 'attrib3', value: undefined } # remove from master
-      { action: 'setAttribute', variantId: 1, name: 'attrib3', value: 'CHANGED3' } # set on variant v1
+      { action: 'setAttribute', sku: 'v3', name: 'attrib3', value: undefined } # remove from master
+      { action: 'setAttribute', sku: 'v1', name: 'attrib3', value: 'CHANGED3' } # set on variant v1
     ]

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -495,8 +495,8 @@ describe 'ProductSync', ->
 
         update = @sync._doMapVariantActions newProduct, oldProduct
         expect(update.variantUpdateActions).toEqual [
-          {action: 'addPrice', variantId: 2, price: {value: {currencyCode: 'EUR', centAmount: 5}, customerGroup: {id: '987', typeId: 'customer-group'}}}
-          {action: 'addPrice', variantId: 2, price: {value: {currencyCode: 'EUR', centAmount: 20}, country: 'DE'}}
+          {action: 'addPrice', sku: 'foo', price: {value: {currencyCode: 'EUR', centAmount: 5}, customerGroup: {id: '987', typeId: 'customer-group'}}}
+          {action: 'addPrice', sku: 'foo', price: {value: {currencyCode: 'EUR', centAmount: 20}, country: 'DE'}}
         ]
 
       it 'should build change price actions', ->
@@ -878,10 +878,10 @@ describe 'ProductSync', ->
         variantActionTypes = @sync._doMapVariantActions(NEW, OLD)
 
         expected_update = [
-          { action: 'setProductVariantKey', variantId: 1, key: 'newKey' }
-          { action: 'setProductVariantKey', variantId: 2, key: 'newVariantKey' }
-          { action: 'setProductVariantKey', variantId: 3, key: undefined }
-          { action: 'setProductVariantKey', variantId: 4, key: 'newVariantKey3' }
+          { action: 'setProductVariantKey', sku: 'masterSku', key: 'newKey' }
+          { action: 'setProductVariantKey', sku: 'variantSku', key: 'newVariantKey' }
+          { action: 'setProductVariantKey', sku: 'variantSku2', key: undefined }
+          { action: 'setProductVariantKey', sku: 'variantSku3', key: 'newVariantKey3' }
         ]
         expect(variantActionTypes.variantUpdateActions).toEqual expected_update
 
@@ -1139,8 +1139,8 @@ describe 'ProductSync', ->
         update = @sync._doMapVariantActions newProduct, oldProduct
         expected_update =
           [
-            { action: 'setAttribute', variantId: 1, name: 'testAttribute1', value: false },
-            { action: 'setAttribute', variantId: 1, name: 'testAttribute2' }
+            { action: 'setAttribute', sku: 'test_sku_1', name: 'testAttribute1', value: false },
+            { action: 'setAttribute', sku: 'test_sku_1', name: 'testAttribute2' }
           ]
         # should not modify original old project
         expect(oldProductClone.masterVariant.attributes).toEqual oldProduct.masterVariant.attributes
@@ -1374,9 +1374,9 @@ describe 'ProductSync', ->
       update = @sync.buildActions(newProduct, oldProduct).getUpdatePayload()
       expected_update =
         actions: [
-          { action: 'setAttribute', variantId: 1, name: 'foo', value: 'new value' }
-          { action: 'setAttribute', variantId: 2, name: 'foo', value: 'another value' }
-          { action: 'setAttribute', variantId: 3, name: 'foo', value: 'yet another' }
+          { action: 'setAttribute', sku: 'v1', name: 'foo', value: 'new value' }
+          { action: 'setAttribute', sku: 'v2', name: 'foo', value: 'another value' }
+          { action: 'setAttribute', sku: 'v3', name: 'foo', value: 'yet another' }
           { action: 'addVariant', id: 4, sku: 'v4', attributes: [{ name: 'foo', value: 'i dont care' }] }
         ]
         version: oldProduct.version

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -667,8 +667,8 @@ describe 'ProductSync', ->
           { action: 'addExternalImage', variantId: 3, image: { url: '//example.com/image2.png', label: 'foo', dimensions: { x: 400, y: 300 } } }
         ]
         expected_update = [
-          # expect a change label action for the first image of variant 3
-          { action: 'changeImageLabel', variantId: 3, imageUrl: '//example.com/image1.png', label: 'CHANGED' }
+          # expect a set image label action for the first image of variant 3
+          { action: 'setImageLabel', variantId: 3, imageUrl: '//example.com/image1.png', label: 'CHANGED' }
           # for the third image of the variant with the id 3 the image url changed
           # which should result in a remove+add action
           { action: 'removeImage', variantId: 3, imageUrl: '//example.com/image3.png' }

--- a/src/spec/sync/utils/product.spec.coffee
+++ b/src/spec/sync/utils/product.spec.coffee
@@ -499,7 +499,7 @@ describe 'ProductUtils', ->
         key: 'oldVar'
 
       expect( () => @utils.buildChangeMasterVariantAction(newMasterVariant, oldMasterVariant))
-        .toThrow new Error('ProductSync needs at least one of "id" or "sku" to generate changeMasterVariant update action')
+        .toThrow new Error('ProductSync needs at least one of "id" or "sku" to generate "changeMasterVariant" update action')
 
   describe ':: buildVariantBaseAction', ->
 
@@ -818,9 +818,9 @@ describe 'ProductUtils', ->
       update = @utils.buildVariantAttributesActions diff.attributes, oldVariant, newVariant
       expected_update =
         [
-          { action: 'setAttribute', variantId: 1, name: 'images', value: '//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-1.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-2.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-4.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-5.jpg' },
-          { action: 'setAttribute', variantId: 1, name: 'textAttribute', value: '[{"textAttributeValue":{"fr-CH":"","de-CH":"","it-CH":"","de-DE":"<p><strong>Some random text to make this longer than the value that was in jsondiffpatch.textDiff.minLength = 300. This should be now a correctly formatted JSON. However, after jsondiffpatch, it will be changed into a different string”</p>","en-GB":"","es-ES":"","fr-FR":""}}]' },
-          { action: 'setAttribute', variantId: 1, name: 'localized_images', value: { en: '//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-1.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-2.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-4.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-5.jpg' } }
+          { action: 'setAttribute', sku: 'HARJPUL101601202', name: 'images', value: '//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-1.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-2.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-4.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-5.jpg' },
+          { action: 'setAttribute', sku: 'HARJPUL101601202', name: 'textAttribute', value: '[{"textAttributeValue":{"fr-CH":"","de-CH":"","it-CH":"","de-DE":"<p><strong>Some random text to make this longer than the value that was in jsondiffpatch.textDiff.minLength = 300. This should be now a correctly formatted JSON. However, after jsondiffpatch, it will be changed into a different string”</p>","en-GB":"","es-ES":"","fr-FR":""}}]' },
+          { action: 'setAttribute', sku: 'HARJPUL101601202', name: 'localized_images', value: { en: '//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-1.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-2.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-4.jpg;//dceroyf7rfc0x.cloudfront.net/product/images/390x520/a/arj/po/HARJPUL101601-5.jpg' } }
         ]
       expect(update).toEqual expected_update
 


### PR DESCRIPTION
### Summary:
Pr is changing the product variant actions, now it's using SKU as the first option for variant update actions:

for example `setAttribute` action documentation explains it :
`variantId - Number or sku - String - Required`
 
#### Why we needed it?

We have lots of these kinds of errors: A staged variant with variantId '3' does not exist... I checked one of the product and it indeed doesn’t have that variant. I also checked the history of that product in master because I thought that the product could have before 3 variants and then one got removed. But it always has 2 variants. So it’s weird that we try to update with variant 3 when this variant never existed.

**It might not resolve the issue for us but could help with finding the reason.**

#### Error message from the API:
```
{
      action: {
       action: "setAttribute"        
       name: "attributeName"        
       staged: true        
       value: [
        0: "AU:0"         
        1: "DE:0"         
        2: "FR:0"         
        3: "NL:0"         
        4: "NZ:0"         
       ]
       variantId: 3        
      }
      actionIndex: 7       
      code: "InvalidOperation"       
      message: "A staged variant with variantId '3' does not exist."       
}
```

**Review Note**: I did not add additional tests for the case, currently the cases already covered, so I just updated the existing ones.
